### PR TITLE
Exclude generated codes from Linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/validate-json/* linguist-vendored


### PR DESCRIPTION
# .gitattributes

Add `src/validate-json` to linguist-vendored 