### PR TITLE
Enable exactOptionalPropertyTypes

### DIFF
--- a/src/content-twitter/component/copy-button.tsx
+++ b/src/content-twitter/component/copy-button.tsx
@@ -147,9 +147,9 @@ export const CopyButton: React.FC<CopyButtonProps> = ({ tweetID }) => {
           style={{ position: strategy, top: y ?? 0, left: x ?? 0 }}>
           <TooltipBody
             message={tooltipMessage.message}
-            onClose={
-              tooltipMessage.type === 'error' ? onTooltipClose : undefined
-            }
+            {...(tooltipMessage.type === 'error'
+              ? { onClose: onTooltipClose }
+              : {})}
           />
           <div
             className="arrow"

--- a/src/lib/parse-tweets.ts
+++ b/src/lib/parse-tweets.ts
@@ -70,8 +70,10 @@ const parseTweet = (
     timestamp,
     author,
     text,
-    annotations,
-    referenced_tweets: referencedTweets,
+    ...(annotations !== undefined ? { annotations } : {}),
+    ...(referencedTweets !== undefined
+      ? { referenced_tweets: referencedTweets }
+      : {}),
   };
 };
 
@@ -260,7 +262,7 @@ const toTweetEntityURL = (
           text,
           media_key: mediaKey,
           media_type: medium.type,
-          url: medium.url,
+          ...(medium.url !== undefined ? { url: medium.url } : {}),
         },
         ...position,
       };
@@ -273,8 +275,10 @@ const toTweetEntityURL = (
         url: entity.expanded_url,
         display_url: entity.display_url,
         decoded_url: decodeURL(entity.expanded_url),
-        title: entity.title,
-        description: entity.description,
+        ...(entity.title !== undefined ? { title: entity.title } : {}),
+        ...(entity.description !== undefined
+          ? { description: entity.description }
+          : {}),
       },
       ...position,
     };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "commonjs",
     "rootDir": "src",


### PR DESCRIPTION
# Enable exactOptionalPropertyTypes

Set `compilerOptions.exactOptionalPropertyTypes` to `true` in tsconfig.json.

Since `isJSOnable({ foo: undefined })` is `false`, Logger output is not as expected.


Use spread syntax(`...`) to fix build errors.
```tsx
// Interface
// before
{
  // ...
  foo: bar,
}
// after
{
  // ...
  ...(bar !== undefined) ? { foo: bar } : {}),
}

// React props
// before
<div onClick={condition ? click : undefined}>
// after
<div {...(condition ? { onClick: click } : {})}>
```