### PR TITLE
Expand t.co URL

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -151,6 +151,7 @@ if (process.env.TARGET_BROWSER === 'firefox') {
           'https://api.twitter.com/*',
           'https://twitter.com/*',
           'https://scrapbox.io/*',
+          'https://*/*',
         ],
       });
       // open popup

--- a/src/content-twitter/component/copy-button.tsx
+++ b/src/content-twitter/component/copy-button.tsx
@@ -105,8 +105,9 @@ export const CopyButton: React.FC<CopyButtonProps> = ({ tweetID }) => {
     );
     // parse tweet
     if (ref?.current) {
-      const tweet = parseTweet(tweetID, ref.current);
-      logger.debug('tweet', tweet);
+      parseTweet(tweetID, ref.current).then((tweet) =>
+        logger.debug('tweet', tweet),
+      );
     }
     // send message to background
     logger.info(`[Tweet ID: ${tweetID}] copy request`);

--- a/src/content-twitter/lib/parse-tweet-text.ts
+++ b/src/content-twitter/lib/parse-tweet-text.ts
@@ -1,5 +1,10 @@
+import browser from 'webextension-polyfill';
 import { getElement, isHTMLElement } from '~/lib/dom';
 import { Logger, logger as defaultLogger } from '~/lib/logger';
+import {
+  ExpandTCoURLRequestMessage,
+  ExpandTCoURLResponseMessage,
+} from '~/lib/message';
 import { formatTCoURL } from '~/lib/url';
 import {
   TweetEntity,
@@ -108,6 +113,20 @@ const parseEntityURL = (
       return '';
     })
     .join('');
+  // request expand https://t.co/...
+  const requestMessage: ExpandTCoURLRequestMessage = {
+    type: 'ExpandTCoURL/Request',
+    shortURL,
+  };
+  logger.debug('Request to expand t.co URL', requestMessage);
+  browser.runtime
+    .sendMessage(requestMessage)
+    .then((responseMessage: ExpandTCoURLResponseMessage) => {
+      logger.debug('Response to request', responseMessage);
+      if (responseMessage?.type !== 'ExpandTCoURL/Response') {
+        logger.warn('Unexpected response message', responseMessage);
+      }
+    });
   return { type: 'url', short_url: shortURL, text };
 };
 

--- a/src/content-twitter/lib/parse-tweet-text.ts
+++ b/src/content-twitter/lib/parse-tweet-text.ts
@@ -1,5 +1,6 @@
 import { getElement, isHTMLElement } from '~/lib/dom';
 import { Logger, logger as defaultLogger } from '~/lib/logger';
+import { formatTCoURL } from '~/lib/url';
 import {
   TweetEntity,
   TweetEntityCashtag,
@@ -91,7 +92,7 @@ const parseEntityURL = (
   logger: Logger,
 ): TweetEntityURL | null => {
   logger.debug('URL entity element', entity);
-  const shortURL = parseShortURL(entity.getAttribute('href') ?? '');
+  const shortURL = formatTCoURL(entity.getAttribute('href') ?? '');
   const text = [...entity.childNodes]
     .map((node) => {
       // text node
@@ -108,18 +109,6 @@ const parseEntityURL = (
     })
     .join('');
   return { type: 'url', short_url: shortURL, text };
-};
-
-const parseShortURL = (href: string): string => {
-  try {
-    const url = new URL(href);
-    return `${url.origin}${url.pathname}`;
-  } catch (error) {
-    if (!(error instanceof TypeError)) {
-      throw error;
-    }
-  }
-  return href;
 };
 
 const parseEntityHashtag = (

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -1,5 +1,6 @@
 import { getElement, getElements, getNode } from '~/lib/dom';
 import { Logger, logger as defaultLogger } from '~/lib/logger';
+import { formatTCoURL, formatTwimgURL } from '~/lib/url';
 import { parseTweetText } from './parse-tweet-text';
 import {
   Card,
@@ -183,22 +184,7 @@ const parseMediaPhoto = (
     logger.warn('<img src="..."> is not found in MediaPhoto');
     return null;
   }
-  return { type: 'photo', url: parseMediaPhotoURL(src.textContent ?? '') };
-};
-
-const parseMediaPhotoURL = (src: string): string => {
-  try {
-    const url = new URL(src);
-    const format = url.searchParams.get('format');
-    if (format !== null) {
-      return `${url.origin}${url.pathname}.${format}`;
-    }
-  } catch (error) {
-    if (!(error instanceof TypeError)) {
-      throw error;
-    }
-  }
-  return src;
+  return { type: 'photo', url: formatTwimgURL(src.textContent ?? '') };
 };
 
 const parseMediaVideo = (
@@ -230,7 +216,7 @@ const parseCard = (tweet: Element, logger: Logger): Card | null => {
     return null;
   }
   return {
-    link_url: link,
+    link_url: formatTCoURL(link),
     image_url: image,
   };
 };

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -12,11 +12,11 @@ import {
   User,
 } from './tweet';
 
-export const parseTweet = (
+export const parseTweet = async (
   id: TweetID,
   element: Element,
   logger: Logger = defaultLogger,
-): Tweet | null => {
+): Promise<Tweet | null> => {
   const tweet = getElement('ancestor::article[@data-testid="tweet"]', element);
   logger.debug('tweet element', tweet);
   if (tweet === null) {
@@ -38,7 +38,7 @@ export const parseTweet = (
     return null;
   }
   // Tweet.text
-  const text = parseTweetText(tweet, logger);
+  const text = await parseTweetText(tweet, logger);
   logger.debug('Tweet.text', text);
   const result: Tweet = { id, timestamp, author, text };
   // card

--- a/src/content-twitter/lib/tweet.ts
+++ b/src/content-twitter/lib/tweet.ts
@@ -14,6 +14,8 @@ export interface TweetEntityURL {
   type: 'url';
   text: string;
   short_url: string;
+  expanded_url: string;
+  title?: string;
 }
 
 export interface TweetEntityHashtag {

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -33,3 +33,26 @@ export interface TweetCopyFailureMessage {
 export type TweetCopyResponseMessage =
   | TweetCopySuccessMessage
   | TweetCopyFailureMessage;
+
+export interface ExpandTCoURLRequestMessage {
+  type: 'ExpandTCoURL/Request';
+  shortURL: string;
+}
+
+export interface ExpandTCoURLSuccessMessage {
+  type: 'ExpandTCoURL/Response';
+  ok: true;
+  shortURL: string;
+  expandedURL: string;
+  title?: string;
+}
+
+export interface ExpandTCoURLFailureMessage {
+  type: 'ExpandTCoURL/Response';
+  ok: false;
+  shortURL: string;
+}
+
+export type ExpandTCoURLResponseMessage =
+  | ExpandTCoURLSuccessMessage
+  | ExpandTCoURLFailureMessage;

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,30 @@
+export const formatTCoURL = (url: string): string => {
+  try {
+    const address = new URL(url);
+    if (address.hostname === 't.co') {
+      return `${address.origin}${address.pathname}`;
+    }
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
+  }
+  return url;
+};
+
+export const formatTwimgURL = (url: string): string => {
+  try {
+    const address = new URL(url);
+    if (address.hostname === 'pbs.twimg.com') {
+      const format = address.searchParams.get('format');
+      if (format !== null) {
+        return `${address.origin}${address.pathname}.${format}`;
+      }
+    }
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
+  }
+  return url;
+};

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,3 +1,16 @@
+import { Logger, logger as defaultLogger } from '~/lib/logger';
+
+export const isTCoURL = (url: string): boolean => {
+  try {
+    return new URL(url).hostname === 't.co';
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
+  }
+  return false;
+};
+
 export const formatTCoURL = (url: string): string => {
   try {
     const address = new URL(url);
@@ -10,6 +23,30 @@ export const formatTCoURL = (url: string): string => {
     }
   }
   return url;
+};
+
+export const expandTCoURL = async (
+  url: string,
+  logger: Logger = defaultLogger,
+): Promise<string | null> => {
+  logger.debug(`expand ${url}`);
+  if (!isTCoURL(url)) {
+    logger.warn(`URL("${url}") is not 'https:/t.co/...'`);
+    return null;
+  }
+  const expandedURL = await fetch(url)
+    .then((response) => response.text())
+    .then((text) => {
+      const parser = new DOMParser();
+      const dom = parser.parseFromString(text, 'text/html');
+      return dom.title;
+    })
+    .catch((error) => {
+      logger.warn(`Failed to expand "${url}"`, error);
+      return null;
+    });
+  logger.debug(`Expanded URL is "${expandedURL}"`);
+  return expandedURL;
 };
 
 export const formatTwimgURL = (url: string): string => {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,10 +5,11 @@
 
   "__prod__permissions": ["storage", "tabs"],
   "__dev__permissions": ["cookies", "storage", "tabs"],
-  "__prod__host_permissions": ["https://api.twitter.com/2/*"],
+  "__prod__host_permissions": ["https://api.twitter.com/2/*", "https://*/*"],
   "__dev__host_permissions": [
     "https://twitter.com/*",
-    "https://api.twitter.com/2/*"
+    "https://api.twitter.com/2/*",
+    "https://*/*"
   ],
 
   "__chrome__background": {


### PR DESCRIPTION
# Expand t.co URL

Add `.expanded_url` and `.title` to `TweetEntityURL`.
- Fetch to the t.co URL to get the expanded URL.
- Fetch to the expanded URL to get the title of the URL.

manifest.json
- Add `https://*/*` to `host_permissions` to get the title of URL.

> **Warning**
URL expansion only works in Firefox.
In Chrome, DOMParser is not defined with Manifest v3.