### PR TITLE
Offscreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
         "@trivago/prettier-plugin-sort-imports": "^4.2.0",
+        "@types/chrome": "^0.0.246",
         "@types/difflib": "^0.2.2",
         "@types/jest": "^29.5.4",
         "@types/react": "^18.2.21",
@@ -4215,6 +4216,16 @@
         "@types/responselike": "*"
       }
     },
+    "node_modules/@types/chrome": {
+      "version": "0.0.246",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.246.tgz",
+      "integrity": "sha512-MxGxEomGxsJiL9xe/7ZwVgwdn8XVKWbPvxpVQl3nWOjrS0Ce63JsfzxUc4aU3GvRcUPYsfufHmJ17BFyKxeA4g==",
+      "dev": true,
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/difflib": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@types/difflib/-/difflib-0.2.2.tgz",
@@ -4247,6 +4258,21 @@
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
       "dev": true
     },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.33.tgz",
+      "integrity": "sha512-2KedRPzwu2K528vFkoXnnWdsG0MtUwPjuA7pRy4vKxlxHEe8qUDZibYHXJKZZr2Cl/ELdCWYqyb/MKwsUuzBWw==",
+      "dev": true,
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.30.tgz",
+      "integrity": "sha512-lB98tui0uxc7erbj0serZfJlHKLNJHwBltPnbmO1WRpL5T325GOHRiQfr2E29V2q+S1brDO63Fpdt6vb3bES9Q==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -4255,6 +4281,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.13.tgz",
+      "integrity": "sha512-PwBsCBD3lDODn4xpje3Y1di0aDJp4Ww7aSfMRVw6ysnxD4I7Wmq2mBkSKaDtN403hqH5sp6c9xQUvFYY3+lkBg==",
+      "dev": true
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -22762,6 +22794,16 @@
         "@types/responselike": "*"
       }
     },
+    "@types/chrome": {
+      "version": "0.0.246",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.246.tgz",
+      "integrity": "sha512-MxGxEomGxsJiL9xe/7ZwVgwdn8XVKWbPvxpVQl3nWOjrS0Ce63JsfzxUc4aU3GvRcUPYsfufHmJ17BFyKxeA4g==",
+      "dev": true,
+      "requires": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "@types/difflib": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@types/difflib/-/difflib-0.2.2.tgz",
@@ -22794,6 +22836,21 @@
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
       "dev": true
     },
+    "@types/filesystem": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.33.tgz",
+      "integrity": "sha512-2KedRPzwu2K528vFkoXnnWdsG0MtUwPjuA7pRy4vKxlxHEe8qUDZibYHXJKZZr2Cl/ELdCWYqyb/MKwsUuzBWw==",
+      "dev": true,
+      "requires": {
+        "@types/filewriter": "*"
+      }
+    },
+    "@types/filewriter": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.30.tgz",
+      "integrity": "sha512-lB98tui0uxc7erbj0serZfJlHKLNJHwBltPnbmO1WRpL5T325GOHRiQfr2E29V2q+S1brDO63Fpdt6vb3bES9Q==",
+      "dev": true
+    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -22802,6 +22859,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/har-format": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.13.tgz",
+      "integrity": "sha512-PwBsCBD3lDODn4xpje3Y1di0aDJp4Ww7aSfMRVw6ysnxD4I7Wmq2mBkSKaDtN403hqH5sp6c9xQUvFYY3+lkBg==",
+      "dev": true
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",
     "@trivago/prettier-plugin-sort-imports": "^4.2.0",
+    "@types/chrome": "^0.0.246",
     "@types/difflib": "^0.2.2",
     "@types/jest": "^29.5.4",
     "@types/react": "^18.2.21",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -17,6 +17,7 @@ import { storage } from '~/lib/storage';
 import { Tweet, TweetID } from '~/lib/tweet';
 import { twitterAPIClient } from '~/lib/twitter-api-client';
 import { expandTCoURL, getURLTitle } from '~/lib/url';
+import { setupOffscreen } from './offscreen';
 
 logger.info('background script');
 
@@ -170,6 +171,12 @@ if (process.env.TARGET_BROWSER === 'firefox') {
       browser.action.setPopup({ popup: null });
     },
   );
+}
+
+// offscreen (for chrome)
+const offscreen = setupOffscreen(logger);
+if (process.env.TARGET_BROWSER === 'chrome') {
+  offscreen.open();
 }
 
 // Respond to ExpandTCoURL/Request

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -8,6 +8,7 @@ import {
   ClipboardOpenRequestMessage,
   ExpandTCoURLRequestMessage,
   ExpandTCoURLResponseMessage,
+  ForwardToOffscreenMessage,
   TweetCopyFailureMessage,
   TweetCopyRequestMessage,
   TweetCopyResponseMessage,
@@ -70,7 +71,9 @@ const onMessageListener = async (
       break;
     case 'ExpandTCoURL/Request':
       logger.info(`Request to expand URL("${message.shortURL}")`);
-      return await respondToExpandTCoURLRequest(message.shortURL);
+      return process.env.TARGET_BROWSER !== 'chrome'
+        ? await respondToExpandTCoURLRequest(message.shortURL)
+        : await forwardExpandTCoURLRequestToOffscreen(message);
     case 'TweetCopy/Request':
       logger.info(`[${message.tweetID}] tweet copy request`);
       twitterClient.requestTweets([message.tweetID]);
@@ -175,9 +178,6 @@ if (process.env.TARGET_BROWSER === 'firefox') {
 
 // offscreen (for chrome)
 const offscreen = setupOffscreen(logger);
-if (process.env.TARGET_BROWSER === 'chrome') {
-  offscreen.open();
-}
 
 // Respond to ExpandTCoURL/Request
 const respondToExpandTCoURLRequest = async (
@@ -201,4 +201,21 @@ const respondToExpandTCoURLRequest = async (
     expandedURL,
     ...(title !== null ? { title } : {}),
   };
+};
+
+// Forward ExpandTCoURL/Request to offscreen
+const forwardExpandTCoURLRequestToOffscreen = async (
+  message: ExpandTCoURLRequestMessage,
+): Promise<ExpandTCoURLResponseMessage> => {
+  await offscreen.open();
+  logger.debug('forward to offscreen', message);
+  const request: ForwardToOffscreenMessage<ExpandTCoURLRequestMessage> = {
+    type: 'Forward/ToOffscreen',
+    message,
+  };
+  const response: ExpandTCoURLResponseMessage =
+    await browser.runtime.sendMessage(request);
+  logger.debug('response from offscreen', response);
+  await offscreen.close();
+  return response;
 };

--- a/src/background/offscreen.ts
+++ b/src/background/offscreen.ts
@@ -1,0 +1,67 @@
+import browser from 'webextension-polyfill';
+import { Logger, logger as defaultLogger } from '~/lib/logger';
+
+export interface Offscreen {
+  exists: () => Promise<boolean>;
+  open: () => Promise<void>;
+  close: () => Promise<void>;
+}
+
+let opening: Promise<void> | null = null;
+
+const setupOffscreenImpl = (logger: Logger = defaultLogger): Offscreen => {
+  const url = browser.runtime.getURL('offscreen.html');
+
+  const exists = async (): Promise<boolean> => {
+    // @ts-expect-error chrome.runtime.getContexts is available from Chrome 116
+    const contexts = await chrome.runtime.getContexts({
+      contextTypes: ['OFFSCREEN_DOCUMENT'],
+      documentUrls: [url],
+    });
+    return contexts.length > 0;
+  };
+
+  const open = async (): Promise<void> => {
+    logger.debug('open offscreen');
+    if (await exists()) {
+      logger.warn('offscreen is already opened');
+      return;
+    }
+    if (opening !== null) {
+      logger.warn('offscreen is currently beeing opened');
+      return;
+    }
+    opening = chrome.offscreen.createDocument({
+      url,
+      reasons: [chrome.offscreen.Reason.DOM_PARSER],
+      justification: 'expand t.co URL',
+    });
+    await opening;
+    opening = null;
+  };
+
+  const close = async (): Promise<void> => {
+    logger.debug('close offscreen');
+    await chrome.offscreen.closeDocument();
+  };
+  return {
+    exists,
+    open,
+    close,
+  };
+};
+
+const setupOffscreenDummy = (): Offscreen => {
+  return {
+    async exists() {
+      return false;
+    },
+    async open() {},
+    async close() {},
+  };
+};
+
+export const setupOffscreen: (logger?: Logger) => Offscreen =
+  process.env.TARGET_BROWSER === 'chrome'
+    ? setupOffscreenImpl
+    : setupOffscreenDummy;

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -56,3 +56,8 @@ export interface ExpandTCoURLFailureMessage {
 export type ExpandTCoURLResponseMessage =
   | ExpandTCoURLSuccessMessage
   | ExpandTCoURLFailureMessage;
+
+export interface ForwardToOffscreenMessage<Message> {
+  type: 'Forward/ToOffscreen';
+  message: Message;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,8 +3,10 @@
   "name": "Scrapbox Copy Tweets",
   "version": "_",
 
-  "__prod__permissions": ["storage", "tabs"],
-  "__dev__permissions": ["cookies", "storage", "tabs"],
+  "__chrome|prod__permissions": ["offscreen", "storage", "tabs"],
+  "__chrome|dev__permissions": ["cookies", "offscreen", "storage", "tabs"],
+  "__firefox|prod__permissions": ["storage", "tabs"],
+  "__firefox|dev__permissions": ["cookies", "storage", "tabs"],
   "__prod__host_permissions": ["https://api.twitter.com/2/*", "https://*/*"],
   "__dev__host_permissions": [
     "https://twitter.com/*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -43,5 +43,7 @@
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true
-  }
+  },
+
+  "__chrome__minimum_chrome_version": "116"
 }

--- a/src/offscreen/index.html
+++ b/src/offscreen/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+  </body>
+</html>

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,0 +1,63 @@
+import browser from 'webextension-polyfill';
+import { logger } from '~/lib/logger';
+import {
+  ExpandTCoURLRequestMessage,
+  ExpandTCoURLResponseMessage,
+  ForwardToOffscreenMessage,
+} from '~/lib/message';
+import { expandTCoURL, getURLTitle } from '~/lib/url';
+
+// runtime.onMessage
+type ForwardedMessage = ExpandTCoURLRequestMessage;
+type RequestMessage = ForwardToOffscreenMessage<ForwardedMessage>;
+type ResponseMessage = ExpandTCoURLResponseMessage;
+
+const listener = async (
+  message: RequestMessage,
+): Promise<ResponseMessage | void> => {
+  logger.debug('[offscreen] on message', message);
+  switch (message?.type) {
+    case 'Forward/ToOffscreen':
+      return await respondToForwardedMessage(message.message);
+    default:
+      logger.debug('[offscreen] skip message', message);
+  }
+};
+
+browser.runtime.onMessage.addListener(listener);
+
+// respond to Forward/ToOffscreen
+const respondToForwardedMessage = async (
+  message: ForwardedMessage,
+): Promise<ResponseMessage | void> => {
+  switch (message?.type) {
+    case 'ExpandTCoURL/Request':
+      return await respondToExpandTCoURLRequest(message.shortURL);
+    default:
+      logger.debug('[offscreen] unexpected forwarded message', message);
+  }
+};
+
+// respond to ExpandTCoURL/Request
+const respondToExpandTCoURLRequest = async (
+  shortURL: string,
+): Promise<ExpandTCoURLResponseMessage> => {
+  // expand https://t.co/...
+  const expandedURL = await expandTCoURL(shortURL, logger);
+  if (expandedURL === null) {
+    return {
+      type: 'ExpandTCoURL/Response',
+      ok: false,
+      shortURL,
+    };
+  }
+  // get title
+  const title = await getURLTitle(expandedURL, logger);
+  return {
+    type: 'ExpandTCoURL/Response',
+    ok: true,
+    shortURL,
+    expandedURL,
+    ...(title !== null ? { title } : {}),
+  };
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,9 @@ module.exports = (env, argv) => {
       options: './src/options/index.tsx',
       popup: './src/popup/index.tsx',
       manifest: './src/manifest.json',
+      ...(browser === 'chrome'
+        ? { offscreen: './src/offscreen/index.ts' }
+        : {}),
     },
     output: {
       path: path.join(__dirname, 'build', mode, browser),
@@ -101,6 +104,15 @@ module.exports = (env, argv) => {
         template: 'src/popup/index.html',
         chunks: ['popup'],
       }),
+      ...(browser === 'chrome'
+        ? [
+            new HtmlPlugin({
+              filename: 'offscreen.html',
+              template: 'src/offscreen/index.html',
+              chunks: ['offscreen'],
+            }),
+          ]
+        : []),
       new MiniCssExtractPlugin(),
       new NodePolyfillPlugin(),
       new WextManifestPlugin(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = (env, argv) => {
     devtool: mode === 'production' ? false : 'cheap-source-map',
     context: __dirname,
     entry: {
-      background: './src/background.ts',
+      background: './src/background/index.ts',
       clipboard: './src/clipboard/index.tsx',
       'content-scrapbox': './src/content-scrapbox/index.tsx',
       'content-twitter': './src/content-twitter/index.tsx',


### PR DESCRIPTION
 # Add offscreen to use DOMParser in Chrome

In Chrome, DOMParser cannot be used in background scripts (service worker) with Manifest v3.
Therefore, use DOMParser via offscreen.

manifest.json
- Add offscreen to permissions.
- Set minimum_chrome_version to 116 to use `chrome.runtime.getContexts()`.

packages
- Add `@types/chrome` to dev-dependencies.
