### PR TITLE
Fix optimization.minimizer of Webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,7 @@ module.exports = (env, argv) => {
       ],
     },
     optimization: {
-      minimizer: [new CssMinimizerPlugin()],
+      minimizer: ['...', new CssMinimizerPlugin()],
     },
     resolve: {
       alias: {


### PR DESCRIPTION
# Fix optimization.minimizer

The default setting of optimization.minimizer was overridden when adding the CssMinimizerPlugin(#5).