### PR TITLE
Parse Card

### DIFF
--- a/src/content-twitter/lib/error.ts
+++ b/src/content-twitter/lib/error.ts
@@ -1,0 +1,14 @@
+import { TweetID } from './tweet';
+
+export class ParseTweetError extends Error {
+  readonly tweetID: TweetID;
+
+  constructor(tweetID: TweetID, message: string) {
+    super(message);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ParseTweetError);
+    }
+    this.name = 'ParseTweetError';
+    this.tweetID = tweetID;
+  }
+}

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -54,7 +54,7 @@ export const parseTweet = async (
   logger.debug('Tweet.text', text);
   const result: Tweet = { id, timestamp, author, text };
   // card
-  const card = await parseCard(tweet, logger);
+  const card = await parseCard(id, tweet, logger);
   logger.debug('Tweet.card', card);
   if (card !== null) {
     result.card = card;
@@ -213,6 +213,7 @@ const parseMediaVideo = (
 };
 
 const parseCard = async (
+  id: TweetID,
   tweet: Element,
   logger: Logger,
 ): Promise<Card | null> => {
@@ -226,7 +227,7 @@ const parseCard = async (
     case 'single':
       return await parseCardSingle(card, logger);
     case 'carousel':
-      return await parseCardCarousel(card, logger);
+      return await parseCardCarousel(id, card, logger);
     default: {
       const _: never = type;
       return _;
@@ -258,6 +259,7 @@ const parseCardSingle = async (
 };
 
 const parseCardCarousel = async (
+  id: TweetID,
   card: Element,
   logger: Logger,
 ): Promise<CardCarousel | null> => {
@@ -271,6 +273,8 @@ const parseCardCarousel = async (
       ?.textContent;
     if (media) {
       mediaURLs.push(media);
+    } else {
+      throw new ParseTweetError(id, 'Some media in carousel ad is not loading');
     }
   }
   // link

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -28,7 +28,7 @@ export const parseTweet = async (
   const tweet = getElement('ancestor::article[@data-testid="tweet"]', element);
   logger.debug('tweet element', tweet);
   if (tweet === null) {
-    logger.warn('<div data-testid="tweet"> is not found');
+    logger.warn('<article data-testid="tweet"> is not found');
     return null;
   }
   // Tweet.timestamp

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -3,7 +3,7 @@ import { Logger, logger as defaultLogger } from '~/lib/logger';
 import { formatTCoURL, formatTwimgURL } from '~/lib/url';
 import { parseTweetText } from './parse-tweet-text';
 import {
-  Card,
+  CardSingle,
   Media,
   MediaPhoto,
   MediaVideo,
@@ -42,7 +42,7 @@ export const parseTweet = async (
   logger.debug('Tweet.text', text);
   const result: Tweet = { id, timestamp, author, text };
   // card
-  const card = parseCard(tweet, logger);
+  const card = parseCardSingle(tweet, logger);
   logger.debug('Tweet.card', card);
   if (card !== null) {
     result.card = card;
@@ -200,7 +200,7 @@ const parseMediaVideo = (
   return { type: 'video', thumbnail: poster.textContent ?? '' };
 };
 
-const parseCard = (tweet: Element, logger: Logger): Card | null => {
+const parseCardSingle = (tweet: Element, logger: Logger): CardSingle | null => {
   const element = getElement('.//div[@data-testid="card.wrapper"]', tweet);
   if (element === null) {
     return null;
@@ -216,6 +216,7 @@ const parseCard = (tweet: Element, logger: Logger): Card | null => {
     return null;
   }
   return {
+    type: 'single',
     link_url: formatTCoURL(link),
     image_url: image,
   };

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -6,6 +6,7 @@ import {
   ExpandTCoURLResponseMessage,
 } from '~/lib/message';
 import { formatTCoURL, formatTwimgURL } from '~/lib/url';
+import { ParseTweetError } from './error';
 import { parseTweetText } from './parse-tweet-text';
 import {
   Card,
@@ -28,22 +29,25 @@ export const parseTweet = async (
   const tweet = getElement('ancestor::article[@data-testid="tweet"]', element);
   logger.debug('tweet element', tweet);
   if (tweet === null) {
-    logger.warn('<article data-testid="tweet"> is not found');
-    return null;
+    const error = '<article data-testid="tweet"> is not found';
+    logger.warn(error);
+    throw new ParseTweetError(id, error);
   }
   // Tweet.timestamp
   const timestamp = parseTimestamp(tweet, logger);
   logger.debug('Tweet.timestamp', timestamp);
   if (timestamp === null) {
-    logger.warn('Failed to parse Tweet.timesamp');
-    return null;
+    const error = 'Failed to parse Tweet.timesamp';
+    logger.warn(error);
+    throw new ParseTweetError(id, error);
   }
   // Tweet.author
   const author = parseUser(tweet, logger);
   logger.debug('Tweet.author', author);
   if (author === null) {
-    logger.warn('Falied to parse Tweet.author');
-    return null;
+    const error = 'Falied to parse Tweet.author';
+    logger.warn(error);
+    throw new ParseTweetError(id, error);
   }
   // Tweet.text
   const text = await parseTweetText(tweet, logger);

--- a/src/content-twitter/lib/tweet.ts
+++ b/src/content-twitter/lib/tweet.ts
@@ -55,10 +55,13 @@ export interface MediaVideo {
 
 export type Media = MediaPhoto | MediaVideo;
 
-export interface Card {
+export interface CardSingle {
+  type: 'single';
   link_url: string;
   image_url: string;
 }
+
+export type Card = CardSingle;
 
 export interface Tweet {
   id: TweetID;

--- a/src/content-twitter/lib/tweet.ts
+++ b/src/content-twitter/lib/tweet.ts
@@ -55,10 +55,16 @@ export interface MediaVideo {
 
 export type Media = MediaPhoto | MediaVideo;
 
+export interface CardLink {
+  url: string;
+  expanded_url: string;
+  title?: string;
+}
+
 export interface CardSingle {
   type: 'single';
-  link_url: string;
-  image_url: string;
+  link?: CardLink;
+  media_url: string;
 }
 
 export type Card = CardSingle;

--- a/src/content-twitter/lib/tweet.ts
+++ b/src/content-twitter/lib/tweet.ts
@@ -67,7 +67,13 @@ export interface CardSingle {
   media_url: string;
 }
 
-export type Card = CardSingle;
+export interface CardCarousel {
+  type: 'carousel';
+  link?: CardLink;
+  media_urls: string[];
+}
+
+export type Card = CardSingle | CardCarousel;
 
 export interface Tweet {
   id: TweetID;


### PR DESCRIPTION
# Parse Card

Add carousel type to Card.
- the previous intarface Card is renamed CardSingle.

Parse video thumbnails.
- If the card's media is video, the URL is not in the DOM, so link is made optional.

Parse carousel ads.

Add ParseTweetError.
- Error if there is media that is not loaded on CardCarousel.
