### PR TITLE
Decode URL

### DIFF
--- a/src/content-twitter/lib/parse-tweet-text.ts
+++ b/src/content-twitter/lib/parse-tweet-text.ts
@@ -5,7 +5,7 @@ import {
   ExpandTCoURLRequestMessage,
   ExpandTCoURLResponseMessage,
 } from '~/lib/message';
-import { formatTCoURL } from '~/lib/url';
+import { decodeURL, formatTCoURL } from '~/lib/url';
 import {
   TweetEntity,
   TweetEntityCashtag,
@@ -138,6 +138,7 @@ const parseEntityURL = async (
     text,
     short_url: shortURL,
     expanded_url: expandedURL,
+    decoded_url: decodeURL(expandedURL),
     ...(title !== undefined ? { title } : {}),
   };
 };

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -5,7 +5,7 @@ import {
   ExpandTCoURLRequestMessage,
   ExpandTCoURLResponseMessage,
 } from '~/lib/message';
-import { formatTCoURL, formatTwimgURL } from '~/lib/url';
+import { decodeURL, formatTCoURL, formatTwimgURL } from '~/lib/url';
 import { ParseTweetError } from './error';
 import { parseTweetText } from './parse-tweet-text';
 import {
@@ -320,6 +320,7 @@ const parseCardLink = async (
   return {
     url,
     expanded_url: expandedURL,
+    decoded_url: decodeURL(expandedURL),
     ...(title !== undefined ? { title } : []),
   };
 };

--- a/src/content-twitter/lib/tweet.ts
+++ b/src/content-twitter/lib/tweet.ts
@@ -15,6 +15,7 @@ export interface TweetEntityURL {
   text: string;
   short_url: string;
   expanded_url: string;
+  decoded_url: string;
   title?: string;
 }
 
@@ -59,6 +60,7 @@ export type Media = MediaPhoto | MediaVideo;
 export interface CardLink {
   url: string;
   expanded_url: string;
+  decoded_url: string;
   title?: string;
 }
 

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,3 +1,4 @@
+import punycode from 'punycode';
 import { Logger, logger as defaultLogger } from '~/lib/logger';
 
 export const isTCoURL = (url: string): boolean => {
@@ -100,4 +101,16 @@ export const getURLTitle = async (
     });
   logger.debug('Get the title of URL', { url, title });
   return title;
+};
+
+export const decodeURL = (url: string): string => {
+  try {
+    const host = new URL(url).host;
+    return decodeURI(url).replace(host, punycode.toUnicode(host));
+  } catch (error) {
+    if (!(error instanceof TypeError) || !(error instanceof URIError)) {
+      throw error;
+    }
+  }
+  return url;
 };


### PR DESCRIPTION
# Decode URL

Add `decodeURL()`
- Converts a Punycode string of ASCII symbols to a string of Unicode symbols.
- Use `decodeURI()` tot decode parcent-encoding.

Add `decoded_url` property to `TweetEntityURL` and `CardLink`.