### PR TITLE
Delete Tweet by Re-Click

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -21,7 +21,7 @@ import {
   TweetSaveResponseSuccessMessage,
 } from '~/lib/message';
 import { loadTestData } from '~/lib/storage';
-import { deleteTweet, saveTweet } from '~/lib/storage/tweet';
+import { deleteTweet, saveTweet, savedTweetIDs } from '~/lib/storage/tweet';
 import { Tweet, TweetID } from '~/lib/tweet/tweet';
 import { expandTCoURL, getURLTitle } from '~/lib/url';
 import { JSONSchemaValidationError } from '~/validate-json/error';
@@ -220,6 +220,16 @@ const respondToTweetSaveRequest = async (
 const respondToTweetDeleteRequest = async (
   tweetID: TweetID,
 ): Promise<TweetDeleteResponseMessage> => {
+  // chefk if tweet exists in storage
+  if (!(await savedTweetIDs()).includes(tweetID)) {
+    const response: TweetDeleteResponseFailureMessage = {
+      type: 'Tweet/DeleteResponse',
+      ok: false,
+      tweetID,
+      error: 'Tweet is not found in storage',
+    };
+    return response;
+  }
   return await deleteTweet(tweetID)
     .then(() => {
       // send Tweet/DeleteReport to all content-twitter

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -255,7 +255,7 @@ const respondToTweetDeleteRequest = async (
         type: 'Tweet/DeleteResponse',
         ok: false,
         tweetID,
-        error: 'Failed to Delete Tweet',
+        error: 'Failed to delete Tweet',
       };
       return response;
     });

--- a/src/content-twitter/component/scrapbox-button.tsx
+++ b/src/content-twitter/component/scrapbox-button.tsx
@@ -14,8 +14,8 @@ import ScrapboxIcon from '~/icon/scrapbox.svg';
 import { Fade } from '~/lib/component/transition';
 import { Logger, createLogger } from '~/lib/logger';
 import {
-  SaveTweetRequestMessage,
-  SaveTweetResponseMessage,
+  TweetSaveRequestMessage,
+  TweetSaveResponseMessage,
 } from '~/lib/message';
 import { toTweetIDKey } from '~/lib/storage/tweet-id-key';
 import { Tweet, TweetID } from '~/lib/tweet/tweet';
@@ -205,14 +205,14 @@ const addTweet = async (
   }
   // send message to background
   logger.info('Save request');
-  const request: SaveTweetRequestMessage = {
-    type: 'SaveTweet/Request',
+  const request: TweetSaveRequestMessage = {
+    type: 'Tweet/SaveRequest',
     tweet: result.tweet,
   };
-  const response: SaveTweetResponseMessage =
+  const response: TweetSaveResponseMessage =
     await browser.runtime.sendMessage(request);
   logger.debug('Save response', response);
-  if (response?.type === 'SaveTweet/Response') {
+  if (response?.type === 'Tweet/SaveResponse') {
     if (response.ok) {
       return result;
     } else {

--- a/src/content-twitter/component/scrapbox-button.tsx
+++ b/src/content-twitter/component/scrapbox-button.tsx
@@ -53,12 +53,8 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
   });
   // tooltip
   const [showTooltip, setShowTooltip] = React.useState(false);
-  const tooltipMessage: TooltipMessage | null =
-    buttonState.state === 'success' ?
-      { type: 'notification', message: 'Copied' }
-    : buttonState.state === 'failure' ?
-      { type: 'error', message: buttonState.message }
-    : null;
+  const [tooltipMessage, setTooltipMessage] =
+    React.useState<TooltipMessage | null>(null);
   // click button
   const onClick = async (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -68,6 +64,7 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
     const result = await addTweet(tweetID, tweetRef.current, logger);
     if (result.ok) {
       dispatch(actions.update({ tweetID, state: { state: 'success' } }));
+      setTooltipMessage({ type: 'notification', message: 'Copied' });
     } else {
       dispatch(
         actions.update({
@@ -75,6 +72,7 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
           state: { state: 'failure', message: result.error },
         }),
       );
+      setTooltipMessage({ type: 'error', message: result.error });
     }
     // show result with tooltip
     setShowTooltip(true);
@@ -103,7 +101,7 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
       </div>
       <Fade
         nodeRef={refs.floating}
-        in={showTooltip}
+        in={showTooltip && tooltipMessage !== null}
         duration={200}
         mountOnEnter
         unmountOnExit
@@ -112,6 +110,7 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
             setTimeout(() => setShowTooltip(false), 2000);
           }
         }}
+        onExited={() => setTooltipMessage(null)}
         target={
           tooltipMessage !== null && (
             <div

--- a/src/content-twitter/component/scrapbox-button.tsx
+++ b/src/content-twitter/component/scrapbox-button.tsx
@@ -254,6 +254,9 @@ const addTweet = async (
     await browser.runtime.sendMessage(request);
   logger.debug('Save response', response);
   if (response?.type === 'Tweet/SaveResponse') {
+    if (response.tweetID !== tweetID) {
+      return { ok: false, error: 'Tweet ID does not match' };
+    }
     if (response.ok) {
       return result;
     } else {

--- a/src/content-twitter/component/scrapbox-button.tsx
+++ b/src/content-twitter/component/scrapbox-button.tsx
@@ -27,6 +27,7 @@ type TooltipType = 'notification' | 'error';
 interface TooltipMessage {
   type: TooltipType;
   message: string;
+  onClosed?: () => void;
 }
 
 export interface ScrapboxButtonProps {
@@ -72,7 +73,12 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
           state: { state: 'failure', message: result.error },
         }),
       );
-      setTooltipMessage({ type: 'error', message: result.error });
+      setTooltipMessage({
+        type: 'error',
+        message: result.error,
+        onClosed: () =>
+          dispatch(actions.update({ tweetID, state: { state: 'none' } })),
+      });
     }
     // show result with tooltip
     setShowTooltip(true);
@@ -87,7 +93,7 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
         ref={refs.setReference}>
         <div
           className={classNames({
-            'circle-inactive': ['none', 'error'].includes(buttonState.state),
+            'circle-inactive': ['none', 'failure'].includes(buttonState.state),
             'circle-in-progress': buttonState.state === 'in-progress',
             'circle-active': buttonState.state === 'success',
           })}
@@ -110,7 +116,10 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
             setTimeout(() => setShowTooltip(false), 2000);
           }
         }}
-        onExited={() => setTooltipMessage(null)}
+        onExited={() => {
+          setTooltipMessage(null);
+          tooltipMessage?.onClosed?.();
+        }}
         target={
           tooltipMessage !== null && (
             <div

--- a/src/content-twitter/component/scrapbox-button.tsx
+++ b/src/content-twitter/component/scrapbox-button.tsx
@@ -76,7 +76,7 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
       );
       setTooltipMessage({
         type: 'error',
-        message: result.error,
+        message: `Failed: ${result.error}`,
         onClosed: () =>
           dispatch(actions.update({ tweetID, state: { state: 'none' } })),
       });
@@ -96,7 +96,7 @@ export const ScrapboxButton: React.FC<ScrapboxButtonProps> = ({ tweetID }) => {
     } else {
       setTooltipMessage({
         type: 'error',
-        message: result.error,
+        message: `Failed: ${result.error}`,
         onClosed: () =>
           dispatch(actions.update({ tweetID, state: { state: 'success' } })),
       });
@@ -263,7 +263,7 @@ const addTweet = async (
       return { ok: false, error: response.error };
     }
   }
-  return { ok: false, error: 'Unknown response from background script' };
+  return { ok: false, error: 'Unknown response' };
 };
 
 interface DeleteTweetSuccess {
@@ -301,5 +301,5 @@ const deleteTweet = async (
       return { ok: false, error: response.error };
     }
   }
-  return { ok: false, error: 'Unknown response form background script' };
+  return { ok: false, error: 'Unknown response' };
 };

--- a/src/content-twitter/component/scrapbox-button.tsx
+++ b/src/content-twitter/component/scrapbox-button.tsx
@@ -244,7 +244,7 @@ const addTweet = async (
   if (!result.ok) {
     return result;
   }
-  // send message to background
+  // send request to background
   logger.info('Save request');
   const request: TweetSaveRequestMessage = {
     type: 'Tweet/SaveRequest',
@@ -260,7 +260,7 @@ const addTweet = async (
       return { ok: false, error: response.error };
     }
   }
-  return { ok: false, error: 'Unknown responses from background script' };
+  return { ok: false, error: 'Unknown response from background script' };
 };
 
 interface DeleteTweetSuccess {

--- a/src/content-twitter/index.tsx
+++ b/src/content-twitter/index.tsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import browser from 'webextension-polyfill';
 import { mutationRecordInfo } from '~/lib/dom';
 import { logger } from '~/lib/logger';
-import { SaveTweetReportMessage } from '~/lib/message';
+import { TweetSaveReportMessage } from '~/lib/message';
 import { savedTweetIDs } from '~/lib/storage/tweet';
 import { ScrapboxButton } from './component/scrapbox-button';
 import './index.scss';
@@ -62,12 +62,12 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 // onMessage listener
-type Message = SaveTweetReportMessage;
+type Message = TweetSaveReportMessage;
 
 const onMessageListener = (message: Message) => {
   logger.debug('on message', message);
   switch (message.type) {
-    case 'SaveTweet/Report':
+    case 'Tweet/SaveReport':
       store.dispatch(
         actions.update({
           tweetID: message.tweetID,

--- a/src/content-twitter/index.tsx
+++ b/src/content-twitter/index.tsx
@@ -87,8 +87,8 @@ const onMessageListener = (message: Message) => {
       );
       break;
     default: {
-      const _: never = message.type;
-      logger.error(`unexpected message "${message}"`);
+      const _: never = message;
+      logger.error('unexpected message', message);
       return _;
     }
   }

--- a/src/content-twitter/index.tsx
+++ b/src/content-twitter/index.tsx
@@ -4,7 +4,10 @@ import { Provider } from 'react-redux';
 import browser from 'webextension-polyfill';
 import { mutationRecordInfo } from '~/lib/dom';
 import { logger } from '~/lib/logger';
-import { TweetSaveReportMessage } from '~/lib/message';
+import {
+  TweetDeleteReportMessage,
+  TweetSaveReportMessage,
+} from '~/lib/message';
 import { savedTweetIDs } from '~/lib/storage/tweet';
 import { ScrapboxButton } from './component/scrapbox-button';
 import './index.scss';
@@ -62,7 +65,7 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 // onMessage listener
-type Message = TweetSaveReportMessage;
+type Message = TweetSaveReportMessage | TweetDeleteReportMessage;
 
 const onMessageListener = (message: Message) => {
   logger.debug('on message', message);
@@ -72,6 +75,14 @@ const onMessageListener = (message: Message) => {
         actions.update({
           tweetID: message.tweetID,
           state: { state: 'success' },
+        }),
+      );
+      break;
+    case 'Tweet/DeleteReport':
+      store.dispatch(
+        actions.update({
+          tweetID: message.tweetID,
+          state: { state: 'none' },
         }),
       );
       break;

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -67,6 +67,33 @@ export interface TweetSaveReportMessage {
   tweetID: TweetID;
 }
 
+export interface TweetDeleteRequestMessage {
+  type: 'Tweet/DeleteRequest';
+  tweetID: TweetID;
+}
+
+export interface TweetDeleteResponseSuccessMessage {
+  type: 'Tweet/DeleteResponse';
+  ok: true;
+  tweetID: TweetID;
+}
+
+export interface TweetDeleteResponseFailureMessage {
+  type: 'Tweet/DeleteResponse';
+  ok: false;
+  tweetID: TweetID;
+  error: string;
+}
+
+export type TweetDeleteResponseMessage =
+  | TweetDeleteResponseSuccessMessage
+  | TweetDeleteResponseFailureMessage;
+
+export interface TweetDeleteReportMessage {
+  type: 'Tweet/DeleteReport';
+  tweetID: TweetID;
+}
+
 export interface SettingsDownloadStorageMessage {
   type: 'Settings/DownloadStorage';
 }

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -40,30 +40,30 @@ export interface ForwardToOffscreenMessage<Message> {
   message: Message;
 }
 
-export interface SaveTweetRequestMessage {
-  type: 'SaveTweet/Request';
+export interface TweetSaveRequestMessage {
+  type: 'Tweet/SaveRequest';
   tweet: Tweet;
 }
 
-export interface SaveTweetResponseSuccessMessage {
-  type: 'SaveTweet/Response';
+export interface TweetSaveResponseSuccessMessage {
+  type: 'Tweet/SaveResponse';
   ok: true;
   tweetID: TweetID;
 }
 
-export interface SaveTweetResponseFailureMessage {
-  type: 'SaveTweet/Response';
+export interface TweetSaveResponseFailureMessage {
+  type: 'Tweet/SaveResponse';
   ok: false;
   tweetID: TweetID;
   error: string;
 }
 
-export type SaveTweetResponseMessage =
-  | SaveTweetResponseSuccessMessage
-  | SaveTweetResponseFailureMessage;
+export type TweetSaveResponseMessage =
+  | TweetSaveResponseSuccessMessage
+  | TweetSaveResponseFailureMessage;
 
-export interface SaveTweetReportMessage {
-  type: 'SaveTweet/Report';
+export interface TweetSaveReportMessage {
+  type: 'Tweet/SaveReport';
   tweetID: TweetID;
 }
 


### PR DESCRIPTION
# Delete Tweet by Re-Click

Clicking the ScrapboxButton on a saved tweet againe will delete that tweet from storage.

Messages
- Rename from 'TweetSave/*' to `Tweet/Save*`.
- Add 'Tweet/Delete*' messages.
- Do not send `*/*Report` to sender.