### PR TITLE
Fix the detemination of promotional tweets

### DIFF
--- a/src/content-twitter/lib/insert-react-root.ts
+++ b/src/content-twitter/lib/insert-react-root.ts
@@ -135,7 +135,8 @@ const createRootDiv = (
   }
   // check if this tweet is a promotion
   if (
-    getElement("../../following-sibling::div//*[name()='svg']", group) !== null
+    getElement("../../following-sibling::div[1]//*[name()='svg']", group) !==
+    null
   ) {
     logger.info('this tweet is a promotion', element);
     return null;


### PR DESCRIPTION
# Fix the detemination of promotional tweets

It gave a false positive for "Who can Reply?"

Change XPath
- from `../../following-sibling::div//*[name()='svg']`
- to `../../following-sibling::div[1]//*[name()='svg']`