### PR TITLE
Fix: Fix validation of URI with fragment as IRI

### DIFF
--- a/src/validate-json/formats/iri.js
+++ b/src/validate-json/formats/iri.js
@@ -13,7 +13,6 @@ function validate(address) {
 
 module.exports = (value) => {
   const iri = parse(value);
-  console.log('iri', iri);
   if (iri.scheme === 'mailto' && iri.to.every(validate)) {
     return true;
   }


### PR DESCRIPTION
# Fix #66

Delete `console.log()` from `validate-json/formats/iri.js`.