### PR TITLE
Modify parseTweet()

### DIFF
--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -82,7 +82,7 @@ const isInQuotedTweet = (element: Element): boolean => {
 };
 
 const parseTimestamp = (tweet: Element, logger: Logger): number | null => {
-  const datetime = getNode('.//time/@datetime', tweet);
+  const datetime = getNode('.//a/time/@datetime', tweet);
   logger.debug('datetime attribute', datetime);
   if (datetime === null) {
     logger.warn('<time datetime="..."> is not found');

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -76,9 +76,7 @@ export const parseTweet = async (
 };
 
 const isInQuotedTweet = (element: Element): boolean => {
-  return (
-    getElement('ancestor::div[div[1]/span[text()="Quote"]]', element) !== null
-  );
+  return getElement('ancestor::div[@role="link"]', element) !== null;
 };
 
 const parseTimestamp = (tweet: Element, logger: Logger): number | null => {


### PR DESCRIPTION
# Modify parseTweet()

`parseTimestamp()`
- Previously, the datetime in the quoted tweet was obtained as the datetime of the tweet. 
- Change XPath from `time/@datetime` to `a//time/@datetime`

`isInQuotedTweet()`
- Change XPath from `ancestor::div[div[1]/span[text()="Quote"]` to `ancestor::div[@role="link"]`.
- the Text `Quote` depends on language settings.