### PR TITLE
Parse card as TweetEntityURL

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,7 @@ module.exports = [
       ...reactHooks.configs.recommended.rules,
       ...reactRedux.configs.recommended.rules,
       ...prettier.rules,
+      'no-redeclare': 'off',
       'require-jsdoc': 'off',
       '@typescript-eslint/no-unused-vars': [
         'error',
@@ -71,6 +72,7 @@ module.exports = [
       ...js.configs.recommended.rules,
       ...typescript.configs.recommended.rules,
       ...prettier.rules,
+      'no-redeclare': 'off',
       'require-jsdoc': 'off',
       '@typescript-eslint/no-unused-vars': [
         'error',

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,9 +3,12 @@ import { logger } from '~/lib/logger';
 import {
   ExpandTCoURLRequestMessage,
   ExpandTCoURLResponseMessage,
+  GetURLTitleRequestMessage,
+  GetURLTitleResponseMessage,
   SettingsDownloadStorageMessage,
   forwardMessageToOffscreen,
   respondToExpandTCoURLRequest,
+  respondToGetURLTitleRequest,
 } from '~/lib/message';
 import { setupOffscreen } from '~/lib/offscreen';
 import { loadTestData } from '~/lib/storage';
@@ -31,9 +34,10 @@ if (process.env.NODE_ENV !== 'production') {
 // onMessage Listener
 type RequestMessage =
   | ExpandTCoURLRequestMessage
+  | GetURLTitleRequestMessage
   | SettingsDownloadStorageMessage;
 
-type ResponseMessage = ExpandTCoURLResponseMessage;
+type ResponseMessage = ExpandTCoURLResponseMessage | GetURLTitleResponseMessage;
 
 const onMessageListener = async (
   message: RequestMessage,
@@ -45,6 +49,11 @@ const onMessageListener = async (
       logger.info(`Request to expand URL("${message.shortURL}")`);
       return process.env.TARGET_BROWSER !== 'chrome' ?
           await respondToExpandTCoURLRequest(message.shortURL, logger)
+        : await forwardMessageToOffscreen(offscreen, message, logger);
+    case 'GetURLTitle/Request':
+      logger.info(`Request to get the title of URL(${message.url})`);
+      return process.env.TARGET_BROWSER !== 'chrome' ?
+          await respondToGetURLTitleRequest(message.url, logger)
         : await forwardMessageToOffscreen(offscreen, message, logger);
     case 'Settings/DownloadStorage':
       await downloadStorage();

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -2,9 +2,9 @@ import browser from 'webextension-polyfill';
 import { logger } from '~/lib/logger';
 import {
   ExpandTCoURLRequestMessage,
-  ExpandTCoURLResponseMessage,
+  ExpandTCoURLResultMessage,
   GetURLTitleRequestMessage,
-  GetURLTitleResponseMessage,
+  GetURLTitleResultMessage,
   SettingsDownloadStorageMessage,
   forwardMessageToOffscreen,
   respondToExpandTCoURLRequest,
@@ -37,7 +37,7 @@ type RequestMessage =
   | GetURLTitleRequestMessage
   | SettingsDownloadStorageMessage;
 
-type ResponseMessage = ExpandTCoURLResponseMessage | GetURLTitleResponseMessage;
+type ResponseMessage = ExpandTCoURLResultMessage | GetURLTitleResultMessage;
 
 const onMessageListener = async (
   message: RequestMessage,

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,8 +7,8 @@ import {
   SettingsDownloadStorageMessage,
   respondToExpandTCoURLRequest,
 } from '~/lib/message';
+import { setupOffscreen } from '~/lib/offscreen';
 import { loadTestData } from '~/lib/storage';
-import { setupOffscreen } from './offscreen';
 
 logger.info('background script');
 

--- a/src/content-twitter/lib/parse-tweet-text.ts
+++ b/src/content-twitter/lib/parse-tweet-text.ts
@@ -3,7 +3,7 @@ import { getElement, getNode, isHTMLElement } from '~/lib/dom';
 import { Logger, logger as defaultLogger } from '~/lib/logger';
 import {
   ExpandTCoURLRequestMessage,
-  ExpandTCoURLResponseMessage,
+  ExpandTCoURLResultMessage,
 } from '~/lib/message';
 import {
   TweetEntity,
@@ -121,9 +121,9 @@ const parseEntityURL = async (
   logger.debug('Request to expand t.co URL', request);
   const { expandedURL, title } = await browser.runtime
     .sendMessage(request)
-    .then((response: ExpandTCoURLResponseMessage) => {
+    .then((response: ExpandTCoURLResultMessage) => {
       logger.debug('Response to request', response);
-      if (response?.type === 'ExpandTCoURL/Response') {
+      if (response?.type === 'ExpandTCoURL/Result') {
         if (response?.ok) {
           const { expandedURL, title } = response;
           return { expandedURL, title };

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -3,9 +3,9 @@ import { getElement, getElements, getNode, getNodes } from '~/lib/dom';
 import { Logger, logger as defaultLogger } from '~/lib/logger';
 import {
   ExpandTCoURLRequestMessage,
-  ExpandTCoURLResponseMessage,
+  ExpandTCoURLResultMessage,
   GetURLTitleRequestMessage,
-  GetURLTitleResponseMessage,
+  GetURLTitleResultMessage,
 } from '~/lib/message';
 import {
   Media,
@@ -268,9 +268,9 @@ const toEntityURL = async (
     };
     const title = await browser.runtime
       .sendMessage(request)
-      .then((response: GetURLTitleResponseMessage) => {
+      .then((response: GetURLTitleResultMessage) => {
         logger.debug('Response to request', response);
-        if (response?.type === 'GetURLTitle/Response') {
+        if (response?.type === 'GetURLTitle/Result') {
           if (response.ok) {
             return response.title;
           }
@@ -294,9 +294,9 @@ const toEntityURL = async (
   logger.debug('Request to expand t.co URL', request);
   const { expandedURL, title } = await browser.runtime
     .sendMessage(request)
-    .then((response: ExpandTCoURLResponseMessage) => {
+    .then((response: ExpandTCoURLResultMessage) => {
       logger.debug('Response to request', response);
-      if (response?.type === 'ExpandTCoURL/Response') {
+      if (response?.type === 'ExpandTCoURL/Result') {
         if (response?.ok) {
           const { expandedURL, title } = response;
           return { expandedURL, title };

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -244,7 +244,7 @@ const parseCard = async (
   );
   // insert newline
   const lastText = text[text.length - 1];
-  if (lastText?.type === 'text') {
+  if (lastText?.type === 'text' && !lastText.text.endsWith('\n')) {
     lastText.text += '\n';
   } else {
     text.push({ type: 'text', text: '\n' });

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -1,23 +1,21 @@
 import browser from 'webextension-polyfill';
-import { getElement, getElements, getNode } from '~/lib/dom';
+import { getElement, getElements, getNode, getNodes } from '~/lib/dom';
 import { Logger, logger as defaultLogger } from '~/lib/logger';
 import {
   ExpandTCoURLRequestMessage,
   ExpandTCoURLResponseMessage,
 } from '~/lib/message';
 import {
-  Card,
-  CardCarousel,
-  CardLink,
-  CardSingle,
   Media,
   MediaPhoto,
   MediaVideo,
   Tweet,
+  TweetEntity,
+  TweetEntityURL,
   TweetID,
   User,
 } from '~/lib/tweet/types';
-import { decodeURL, formatTCoURL, formatTwimgURL } from '~/lib/url';
+import { decodeURL, formatTwimgURL, isTCoURL } from '~/lib/url';
 import { ParseTweetError } from './error';
 import { parseTweetText } from './parse-tweet-text';
 
@@ -52,6 +50,7 @@ export const parseTweet = async (
   }
   // Tweet.text
   const text = await parseTweetText(tweet, logger);
+  await parseCard(tweet, text, logger);
   logger.debug('Tweet.text', text);
   const result: Tweet = {
     id,
@@ -60,12 +59,6 @@ export const parseTweet = async (
     author,
     text,
   };
-  // card
-  const card = await parseCard(id, tweet, logger);
-  logger.debug('Tweet.card', card);
-  if (card !== null) {
-    result.card = card;
-  }
   // media
   const media = parseMedia(tweet, logger);
   logger.debug('Tweet.media', media);
@@ -218,96 +211,66 @@ const parseMediaVideo = (
 };
 
 const parseCard = async (
-  id: TweetID,
   tweet: Element,
+  text: TweetEntity[],
   logger: Logger,
-): Promise<Card | null> => {
-  const card = getElement('.//div[@data-testid="card.wrapper"]', tweet);
-  if (card === null) {
-    return null;
+): Promise<void> => {
+  const root = getElement('.//div[div[@data-testid="card.wrapper"]]', tweet);
+  logger.debug('card root', root);
+  if (root === null) {
+    return;
   }
-  const type: Card['type'] =
-    getElements('.//ul/li', card).length > 0 ? 'carousel' : 'single';
-  switch (type) {
-    case 'single':
-      return await parseCardSingle(card, logger);
-    case 'carousel':
-      return await parseCardCarousel(id, card, logger);
-    default: {
-      const _: never = type;
-      return _;
+  // URLs in tweet text
+  const textURLs = text.reduce<string[]>((urls, entity) => {
+    if (entity.type === 'url') {
+      urls.push(entity.short_url, entity.expanded_url);
     }
-  }
-};
-
-const parseCardSingle = async (
-  card: Element,
-  logger: Logger,
-): Promise<CardSingle | null> => {
-  if (getElement('self::div[@data-testid="card.wrapper"]', card) === null) {
-    return null;
-  }
-  const media = getNode('.//img/@src | .//video/@poster', card)?.textContent;
-  if (!media) {
-    logger.warn('<img src="..."> or <video poster="..."> is not found in card');
-    return null;
-  }
-  const link = await parseCardLink(
-    getNode('.//a/@href', card)?.textContent,
-    logger,
-  );
-  return {
-    type: 'single',
-    ...(link !== null && { link }),
-    media_url: media,
-  };
-};
-
-const parseCardCarousel = async (
-  id: TweetID,
-  card: Element,
-  logger: Logger,
-): Promise<CardCarousel | null> => {
-  if (getElement('self::div[@data-testid="card.wrapper"]', card) === null) {
-    return null;
-  }
-  // media URLs
-  const mediaURLs: string[] = [];
-  for (const listItem of getElements('.//ul/li', card)) {
-    const media = getNode(
-      './/img/@src | .//video/@poster',
-      listItem,
-    )?.textContent;
-    if (media) {
-      mediaURLs.push(media);
-    } else {
-      throw new ParseTweetError(id, 'Some media in carousel ad is not loading');
+    return urls;
+  }, []);
+  // hrefs in card
+  const hrefs = getNodes('.//a/@href', root).reduce<string[]>((hrefs, node) => {
+    const href = node.textContent;
+    if (href && !hrefs.includes(href) && !textURLs.includes(href)) {
+      hrefs.push(href);
     }
+    return hrefs;
+  }, []);
+  if (!hrefs.length) {
+    return;
   }
-  // link
-  const link = await parseCardLink(
-    getNode('.//a/@href', card)?.textContent,
-    logger,
+  // href to tweetEntityURL
+  const urls = await Promise.all(
+    hrefs.map(async (href) => await toEntityURL(href, logger)),
   );
-  return {
-    type: 'carousel',
-    ...(link !== null && { link }),
-    media_urls: mediaURLs,
-  };
+  // insert newline
+  const lastText = text[text.length - 1];
+  if (lastText?.type === 'text') {
+    lastText.text += '\n';
+  } else {
+    text.push({ type: 'text', text: '\n' });
+  }
+  // append to text
+  text.push(...urls);
 };
 
-const parseCardLink = async (
-  href: string | undefined | null,
+const toEntityURL = async (
+  href: string,
   logger: Logger,
-): Promise<CardLink | null> => {
-  if (!href) {
-    return null;
+): Promise<TweetEntityURL> => {
+  // check if the href is https://t.co/...
+  if (!isTCoURL(href)) {
+    return {
+      type: 'url',
+      text: '',
+      short_url: href,
+      expanded_url: href,
+      decoded_url: decodeURL(href),
+    };
   }
-  const url = formatTCoURL(href);
   // request expand https://t.co/...
   const request: ExpandTCoURLRequestMessage = {
     type: 'ExpandTCoURL/Request',
-    shortURL: url,
+    shortURL: href,
   };
   logger.debug('Request to expand t.co URL', request);
   const { expandedURL, title } = await browser.runtime
@@ -322,10 +285,12 @@ const parseCardLink = async (
       } else {
         logger.warn('Unexpected response message', response);
       }
-      return { expandedURL: url };
+      return { expandedURL: href };
     });
   return {
-    url,
+    type: 'url',
+    text: '',
+    short_url: href,
     expanded_url: expandedURL,
     decoded_url: decodeURL(expandedURL),
     ...(title !== undefined && { title }),

--- a/src/jsonschema/tweet.ts
+++ b/src/jsonschema/tweet.ts
@@ -24,7 +24,6 @@ const definitions: SchemaObject = {
         type: 'array',
         items: { $ref: '#/definitions/entity' },
       },
-      card: { $ref: '#/definitions/card' },
       media: {
         type: 'array',
         items: { $ref: '#/definitions/media' },
@@ -152,53 +151,6 @@ const definitions: SchemaObject = {
       thumbnail: { $ref: '#/definitions/uri' },
     },
     required: ['type', 'thumbnail'],
-    additionalProperties: false,
-  },
-  // Card
-  card: {
-    type: 'object',
-    oneOf: [
-      { $ref: '#/definitions/card:single' },
-      { $ref: '#/definitions/card:carousel' },
-    ],
-    required: ['type'],
-    discriminator: { propertyName: 'type' },
-  },
-  // CardLink
-  'card:link': {
-    type: 'object',
-    properties: {
-      url: { $ref: '#/definitions/uri' },
-      expanded_url: { $ref: '#/definitions/uri' },
-      decoded_url: { $ref: '#/definitions/iri' },
-      title: { type: 'string' },
-    },
-    required: ['url', 'expanded_url', 'decoded_url'],
-    additionalProperties: false,
-  },
-  // CardSingle
-  'card:single': {
-    type: 'object',
-    properties: {
-      type: { const: 'single' },
-      link: { $ref: '#/definitions/card:link' },
-      media_url: { $ref: '#/definitions/uri' },
-    },
-    required: ['type', 'media_url'],
-    additionalProperties: false,
-  },
-  // CardCarousel
-  'card:carousel': {
-    type: 'object',
-    properties: {
-      type: { const: 'carousel' },
-      link: { $ref: '#/definitions/card:link' },
-      media_urls: {
-        type: 'array',
-        items: { $ref: '#/definitions/uri' },
-      },
-    },
-    required: ['type', 'media_urls'],
     additionalProperties: false,
   },
 };

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -1,3 +1,6 @@
+import { Logger } from './logger';
+import { expandTCoURL, getURLTitle } from './url';
+
 export interface ExpandTCoURLRequestMessage {
   type: 'ExpandTCoURL/Request';
   shortURL: string;
@@ -29,3 +32,28 @@ export interface ForwardToOffscreenMessage<Message> {
 export interface SettingsDownloadStorageMessage {
   type: 'Settings/DownloadStorage';
 }
+
+// Respond to ExpandTCoURL/Request
+export const respondToExpandTCoURLRequest = async (
+  shortURL: string,
+  logger: Logger,
+): Promise<ExpandTCoURLResponseMessage> => {
+  // expand https://t.co/...
+  const expandedURL = await expandTCoURL(shortURL, logger);
+  if (expandedURL === null) {
+    return {
+      type: 'ExpandTCoURL/Response',
+      ok: false,
+      shortURL,
+    };
+  }
+  // get title
+  const title = await getURLTitle(expandedURL, logger);
+  return {
+    type: 'ExpandTCoURL/Response',
+    ok: true,
+    shortURL,
+    expandedURL,
+    ...(title !== null && { title }),
+  };
+};

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -1,4 +1,6 @@
+import browser from 'webextension-polyfill';
 import { Logger } from './logger';
+import { Offscreen } from './offscreen';
 import { expandTCoURL, getURLTitle } from './url';
 
 export interface ExpandTCoURLRequestMessage {
@@ -56,4 +58,22 @@ export const respondToExpandTCoURLRequest = async (
     expandedURL,
     ...(title !== null && { title }),
   };
+};
+
+// Forward message to offscreen
+export const forwardMessageToOffscreen = async (
+  offscreen: Offscreen,
+  message: ExpandTCoURLRequestMessage,
+  logger: Logger,
+): Promise<ExpandTCoURLResponseMessage> => {
+  await offscreen.open();
+  logger.debug('forward to offscreen', message);
+  const request = {
+    type: 'Forward/ToOffscreen',
+    message,
+  };
+  const response = await browser.runtime.sendMessage(request);
+  logger.debug('response from offscreen', response);
+  await offscreen.close();
+  return response;
 };

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -9,7 +9,7 @@ export interface ExpandTCoURLRequestMessage {
 }
 
 export interface ExpandTCoURLSuccessMessage {
-  type: 'ExpandTCoURL/Response';
+  type: 'ExpandTCoURL/Result';
   ok: true;
   shortURL: string;
   expandedURL: string;
@@ -17,12 +17,12 @@ export interface ExpandTCoURLSuccessMessage {
 }
 
 export interface ExpandTCoURLFailureMessage {
-  type: 'ExpandTCoURL/Response';
+  type: 'ExpandTCoURL/Result';
   ok: false;
   shortURL: string;
 }
 
-export type ExpandTCoURLResponseMessage =
+export type ExpandTCoURLResultMessage =
   | ExpandTCoURLSuccessMessage
   | ExpandTCoURLFailureMessage;
 
@@ -37,19 +37,19 @@ export interface GetURLTitleRequestMessage {
 }
 
 export interface GetURLTitleSuccessMessage {
-  type: 'GetURLTitle/Response';
+  type: 'GetURLTitle/Result';
   ok: true;
   url: string;
   title: string;
 }
 
 export interface GetURLTitleFailureMessage {
-  type: 'GetURLTitle/Response';
+  type: 'GetURLTitle/Result';
   ok: false;
   url: string;
 }
 
-export type GetURLTitleResponseMessage =
+export type GetURLTitleResultMessage =
   | GetURLTitleSuccessMessage
   | GetURLTitleFailureMessage;
 
@@ -61,12 +61,12 @@ export interface SettingsDownloadStorageMessage {
 export const respondToExpandTCoURLRequest = async (
   shortURL: string,
   logger: Logger,
-): Promise<ExpandTCoURLResponseMessage> => {
+): Promise<ExpandTCoURLResultMessage> => {
   // expand https://t.co/...
   const expandedURL = await expandTCoURL(shortURL, logger);
   if (expandedURL === null) {
     return {
-      type: 'ExpandTCoURL/Response',
+      type: 'ExpandTCoURL/Result',
       ok: false,
       shortURL,
     };
@@ -74,7 +74,7 @@ export const respondToExpandTCoURLRequest = async (
   // get title
   const title = await getURLTitle(expandedURL, logger);
   return {
-    type: 'ExpandTCoURL/Response',
+    type: 'ExpandTCoURL/Result',
     ok: true,
     shortURL,
     expandedURL,
@@ -86,17 +86,17 @@ export const respondToExpandTCoURLRequest = async (
 export const respondToGetURLTitleRequest = async (
   url: string,
   logger: Logger,
-): Promise<GetURLTitleResponseMessage> => {
+): Promise<GetURLTitleResultMessage> => {
   const title = await getURLTitle(url, logger);
   if (title === null) {
     return {
-      type: 'GetURLTitle/Response',
+      type: 'GetURLTitle/Result',
       ok: false,
       url,
     };
   }
   return {
-    type: 'GetURLTitle/Response',
+    type: 'GetURLTitle/Result',
     ok: true,
     url,
     title,
@@ -108,19 +108,19 @@ export async function forwardMessageToOffscreen(
   offscreen: Offscreen,
   message: ExpandTCoURLRequestMessage,
   logger: Logger,
-): Promise<ExpandTCoURLResponseMessage>;
+): Promise<ExpandTCoURLResultMessage>;
 
 export async function forwardMessageToOffscreen(
   offscreen: Offscreen,
   message: GetURLTitleRequestMessage,
   logger: Logger,
-): Promise<GetURLTitleResponseMessage>;
+): Promise<GetURLTitleResultMessage>;
 
 export async function forwardMessageToOffscreen(
   offscreen: Offscreen,
   message: ExpandTCoURLRequestMessage | GetURLTitleRequestMessage,
   logger: Logger,
-): Promise<ExpandTCoURLResponseMessage | GetURLTitleResponseMessage> {
+): Promise<ExpandTCoURLResultMessage | GetURLTitleResultMessage> {
   await offscreen.open();
   logger.debug('forward to offscreen', message);
   const request = {

--- a/src/lib/offscreen.ts
+++ b/src/lib/offscreen.ts
@@ -1,5 +1,5 @@
 import browser from 'webextension-polyfill';
-import { Logger, logger as defaultLogger } from '~/lib/logger';
+import { Logger, logger as defaultLogger } from './logger';
 
 export interface Offscreen {
   exists: () => Promise<boolean>;

--- a/src/lib/tweet/types.ts
+++ b/src/lib/tweet/types.ts
@@ -57,34 +57,12 @@ export interface MediaVideo {
 
 export type Media = MediaPhoto | MediaVideo;
 
-export interface CardLink {
-  url: string;
-  expanded_url: string;
-  decoded_url: string;
-  title?: string;
-}
-
-export interface CardSingle {
-  type: 'single';
-  link?: CardLink;
-  media_url: string;
-}
-
-export interface CardCarousel {
-  type: 'carousel';
-  link?: CardLink;
-  media_urls: string[];
-}
-
-export type Card = CardSingle | CardCarousel;
-
 export interface Tweet {
   id: TweetID;
   created_at: number;
   saved_at: number;
   author: User;
   text: TweetEntity[];
-  card?: Card;
   media?: Media[];
 }
 

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -2,10 +2,10 @@ import browser from 'webextension-polyfill';
 import { createLogger } from '~/lib/logger';
 import {
   ExpandTCoURLRequestMessage,
-  ExpandTCoURLResponseMessage,
+  ExpandTCoURLResultMessage,
   ForwardToOffscreenMessage,
   GetURLTitleRequestMessage,
-  GetURLTitleResponseMessage,
+  GetURLTitleResultMessage,
   respondToExpandTCoURLRequest,
   respondToGetURLTitleRequest,
 } from '~/lib/message';
@@ -16,7 +16,7 @@ const logger = createLogger({ prefix: '[offscreen] ' });
 // runtime.onMessage
 type ForwardedMessage = ExpandTCoURLRequestMessage | GetURLTitleRequestMessage;
 type RequestMessage = ForwardToOffscreenMessage<ForwardedMessage>;
-type ResponseMessage = ExpandTCoURLResponseMessage | GetURLTitleResponseMessage;
+type ResponseMessage = ExpandTCoURLResultMessage | GetURLTitleResultMessage;
 
 const listener = async (
   message: RequestMessage,

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -4,8 +4,8 @@ import {
   ExpandTCoURLRequestMessage,
   ExpandTCoURLResponseMessage,
   ForwardToOffscreenMessage,
+  respondToExpandTCoURLRequest,
 } from '~/lib/message';
-import { expandTCoURL, getURLTitle } from '~/lib/url';
 
 // logger
 const logger = createLogger({ prefix: '[offscreen] ' });
@@ -35,32 +35,8 @@ const respondToForwardedMessage = async (
 ): Promise<ResponseMessage | void> => {
   switch (message?.type) {
     case 'ExpandTCoURL/Request':
-      return await respondToExpandTCoURLRequest(message.shortURL);
+      return await respondToExpandTCoURLRequest(message.shortURL, logger);
     default:
       logger.debug('unexpected forwarded message', message);
   }
-};
-
-// respond to ExpandTCoURL/Request
-const respondToExpandTCoURLRequest = async (
-  shortURL: string,
-): Promise<ExpandTCoURLResponseMessage> => {
-  // expand https://t.co/...
-  const expandedURL = await expandTCoURL(shortURL, logger);
-  if (expandedURL === null) {
-    return {
-      type: 'ExpandTCoURL/Response',
-      ok: false,
-      shortURL,
-    };
-  }
-  // get title
-  const title = await getURLTitle(expandedURL, logger);
-  return {
-    type: 'ExpandTCoURL/Response',
-    ok: true,
-    shortURL,
-    expandedURL,
-    ...(title !== null && { title }),
-  };
 };

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -4,16 +4,19 @@ import {
   ExpandTCoURLRequestMessage,
   ExpandTCoURLResponseMessage,
   ForwardToOffscreenMessage,
+  GetURLTitleRequestMessage,
+  GetURLTitleResponseMessage,
   respondToExpandTCoURLRequest,
+  respondToGetURLTitleRequest,
 } from '~/lib/message';
 
 // logger
 const logger = createLogger({ prefix: '[offscreen] ' });
 
 // runtime.onMessage
-type ForwardedMessage = ExpandTCoURLRequestMessage;
+type ForwardedMessage = ExpandTCoURLRequestMessage | GetURLTitleRequestMessage;
 type RequestMessage = ForwardToOffscreenMessage<ForwardedMessage>;
-type ResponseMessage = ExpandTCoURLResponseMessage;
+type ResponseMessage = ExpandTCoURLResponseMessage | GetURLTitleResponseMessage;
 
 const listener = async (
   message: RequestMessage,
@@ -36,6 +39,8 @@ const respondToForwardedMessage = async (
   switch (message?.type) {
     case 'ExpandTCoURL/Request':
       return await respondToExpandTCoURLRequest(message.shortURL, logger);
+    case 'GetURLTitle/Request':
+      return await respondToGetURLTitleRequest(message.url, logger);
     default:
       logger.debug('unexpected forwarded message', message);
   }

--- a/src/validate-json/validate-tweet.js
+++ b/src/validate-json/validate-tweet.js
@@ -14,7 +14,6 @@ const schema11 = {
         saved_at: { type: 'integer' },
         author: { $ref: '#/definitions/user' },
         text: { type: 'array', items: { $ref: '#/definitions/entity' } },
-        card: { $ref: '#/definitions/card' },
         media: { type: 'array', items: { $ref: '#/definitions/media' } },
       },
       required: ['id', 'created_at', 'saved_at', 'author', 'text'],
@@ -120,46 +119,6 @@ const schema11 = {
       required: ['type', 'thumbnail'],
       additionalProperties: false,
     },
-    card: {
-      type: 'object',
-      oneOf: [
-        { $ref: '#/definitions/card:single' },
-        { $ref: '#/definitions/card:carousel' },
-      ],
-      required: ['type'],
-      discriminator: { propertyName: 'type' },
-    },
-    'card:link': {
-      type: 'object',
-      properties: {
-        url: { $ref: '#/definitions/uri' },
-        expanded_url: { $ref: '#/definitions/uri' },
-        decoded_url: { $ref: '#/definitions/iri' },
-        title: { type: 'string' },
-      },
-      required: ['url', 'expanded_url', 'decoded_url'],
-      additionalProperties: false,
-    },
-    'card:single': {
-      type: 'object',
-      properties: {
-        type: { const: 'single' },
-        link: { $ref: '#/definitions/card:link' },
-        media_url: { $ref: '#/definitions/uri' },
-      },
-      required: ['type', 'media_url'],
-      additionalProperties: false,
-    },
-    'card:carousel': {
-      type: 'object',
-      properties: {
-        type: { const: 'carousel' },
-        link: { $ref: '#/definitions/card:link' },
-        media_urls: { type: 'array', items: { $ref: '#/definitions/uri' } },
-      },
-      required: ['type', 'media_urls'],
-      additionalProperties: false,
-    },
   },
 };
 const schema12 = {
@@ -170,7 +129,6 @@ const schema12 = {
     saved_at: { type: 'integer' },
     author: { $ref: '#/definitions/user' },
     text: { type: 'array', items: { $ref: '#/definitions/entity' } },
-    card: { $ref: '#/definitions/card' },
     media: { type: 'array', items: { $ref: '#/definitions/media' } },
   },
   required: ['id', 'created_at', 'saved_at', 'author', 'text'],
@@ -1340,672 +1298,19 @@ function validate14(
 const schema27 = {
   type: 'object',
   oneOf: [
-    { $ref: '#/definitions/card:single' },
-    { $ref: '#/definitions/card:carousel' },
-  ],
-  required: ['type'],
-  discriminator: { propertyName: 'type' },
-};
-const schema28 = {
-  type: 'object',
-  properties: {
-    type: { const: 'single' },
-    link: { $ref: '#/definitions/card:link' },
-    media_url: { $ref: '#/definitions/uri' },
-  },
-  required: ['type', 'media_url'],
-  additionalProperties: false,
-};
-const schema29 = {
-  type: 'object',
-  properties: {
-    url: { $ref: '#/definitions/uri' },
-    expanded_url: { $ref: '#/definitions/uri' },
-    decoded_url: { $ref: '#/definitions/iri' },
-    title: { type: 'string' },
-  },
-  required: ['url', 'expanded_url', 'decoded_url'],
-  additionalProperties: false,
-};
-function validate24(
-  data,
-  { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
-) {
-  let vErrors = null;
-  let errors = 0;
-  if (data && typeof data == 'object' && !Array.isArray(data)) {
-    if (data.url === undefined) {
-      const err0 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'url' },
-        message: "must have required property '" + 'url' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err0];
-      } else {
-        vErrors.push(err0);
-      }
-      errors++;
-    }
-    if (data.expanded_url === undefined) {
-      const err1 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'expanded_url' },
-        message: "must have required property '" + 'expanded_url' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err1];
-      } else {
-        vErrors.push(err1);
-      }
-      errors++;
-    }
-    if (data.decoded_url === undefined) {
-      const err2 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'decoded_url' },
-        message: "must have required property '" + 'decoded_url' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err2];
-      } else {
-        vErrors.push(err2);
-      }
-      errors++;
-    }
-    for (const key0 in data) {
-      if (
-        !(
-          key0 === 'url' ||
-          key0 === 'expanded_url' ||
-          key0 === 'decoded_url' ||
-          key0 === 'title'
-        )
-      ) {
-        const err3 = {
-          instancePath,
-          schemaPath: '#/additionalProperties',
-          keyword: 'additionalProperties',
-          params: { additionalProperty: key0 },
-          message: 'must NOT have additional properties',
-        };
-        if (vErrors === null) {
-          vErrors = [err3];
-        } else {
-          vErrors.push(err3);
-        }
-        errors++;
-      }
-    }
-    if (data.url !== undefined) {
-      let data0 = data.url;
-      if (typeof data0 === 'string') {
-        if (!formats0(data0)) {
-          const err4 = {
-            instancePath: instancePath + '/url',
-            schemaPath: '#/definitions/uri/format',
-            keyword: 'format',
-            params: { format: 'uri' },
-            message: 'must match format "' + 'uri' + '"',
-          };
-          if (vErrors === null) {
-            vErrors = [err4];
-          } else {
-            vErrors.push(err4);
-          }
-          errors++;
-        }
-      } else {
-        const err5 = {
-          instancePath: instancePath + '/url',
-          schemaPath: '#/definitions/uri/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err5];
-        } else {
-          vErrors.push(err5);
-        }
-        errors++;
-      }
-    }
-    if (data.expanded_url !== undefined) {
-      let data1 = data.expanded_url;
-      if (typeof data1 === 'string') {
-        if (!formats0(data1)) {
-          const err6 = {
-            instancePath: instancePath + '/expanded_url',
-            schemaPath: '#/definitions/uri/format',
-            keyword: 'format',
-            params: { format: 'uri' },
-            message: 'must match format "' + 'uri' + '"',
-          };
-          if (vErrors === null) {
-            vErrors = [err6];
-          } else {
-            vErrors.push(err6);
-          }
-          errors++;
-        }
-      } else {
-        const err7 = {
-          instancePath: instancePath + '/expanded_url',
-          schemaPath: '#/definitions/uri/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err7];
-        } else {
-          vErrors.push(err7);
-        }
-        errors++;
-      }
-    }
-    if (data.decoded_url !== undefined) {
-      let data2 = data.decoded_url;
-      if (typeof data2 === 'string') {
-        if (!formats4(data2)) {
-          const err8 = {
-            instancePath: instancePath + '/decoded_url',
-            schemaPath: '#/definitions/iri/format',
-            keyword: 'format',
-            params: { format: 'iri' },
-            message: 'must match format "' + 'iri' + '"',
-          };
-          if (vErrors === null) {
-            vErrors = [err8];
-          } else {
-            vErrors.push(err8);
-          }
-          errors++;
-        }
-      } else {
-        const err9 = {
-          instancePath: instancePath + '/decoded_url',
-          schemaPath: '#/definitions/iri/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err9];
-        } else {
-          vErrors.push(err9);
-        }
-        errors++;
-      }
-    }
-    if (data.title !== undefined) {
-      if (typeof data.title !== 'string') {
-        const err10 = {
-          instancePath: instancePath + '/title',
-          schemaPath: '#/properties/title/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err10];
-        } else {
-          vErrors.push(err10);
-        }
-        errors++;
-      }
-    }
-  } else {
-    const err11 = {
-      instancePath,
-      schemaPath: '#/type',
-      keyword: 'type',
-      params: { type: 'object' },
-      message: 'must be object',
-    };
-    if (vErrors === null) {
-      vErrors = [err11];
-    } else {
-      vErrors.push(err11);
-    }
-    errors++;
-  }
-  validate24.errors = vErrors;
-  return errors === 0;
-}
-function validate23(
-  data,
-  { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
-) {
-  let vErrors = null;
-  let errors = 0;
-  if (data && typeof data == 'object' && !Array.isArray(data)) {
-    if (data.type === undefined) {
-      const err0 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'type' },
-        message: "must have required property '" + 'type' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err0];
-      } else {
-        vErrors.push(err0);
-      }
-      errors++;
-    }
-    if (data.media_url === undefined) {
-      const err1 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'media_url' },
-        message: "must have required property '" + 'media_url' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err1];
-      } else {
-        vErrors.push(err1);
-      }
-      errors++;
-    }
-    for (const key0 in data) {
-      if (!(key0 === 'type' || key0 === 'link' || key0 === 'media_url')) {
-        const err2 = {
-          instancePath,
-          schemaPath: '#/additionalProperties',
-          keyword: 'additionalProperties',
-          params: { additionalProperty: key0 },
-          message: 'must NOT have additional properties',
-        };
-        if (vErrors === null) {
-          vErrors = [err2];
-        } else {
-          vErrors.push(err2);
-        }
-        errors++;
-      }
-    }
-    if (data.type !== undefined) {
-      if ('single' !== data.type) {
-        const err3 = {
-          instancePath: instancePath + '/type',
-          schemaPath: '#/properties/type/const',
-          keyword: 'const',
-          params: { allowedValue: 'single' },
-          message: 'must be equal to constant',
-        };
-        if (vErrors === null) {
-          vErrors = [err3];
-        } else {
-          vErrors.push(err3);
-        }
-        errors++;
-      }
-    }
-    if (data.link !== undefined) {
-      if (
-        !validate24(data.link, {
-          instancePath: instancePath + '/link',
-          parentData: data,
-          parentDataProperty: 'link',
-          rootData,
-        })
-      ) {
-        vErrors =
-          vErrors === null ?
-            validate24.errors
-          : vErrors.concat(validate24.errors);
-        errors = vErrors.length;
-      }
-    }
-    if (data.media_url !== undefined) {
-      let data2 = data.media_url;
-      if (typeof data2 === 'string') {
-        if (!formats0(data2)) {
-          const err4 = {
-            instancePath: instancePath + '/media_url',
-            schemaPath: '#/definitions/uri/format',
-            keyword: 'format',
-            params: { format: 'uri' },
-            message: 'must match format "' + 'uri' + '"',
-          };
-          if (vErrors === null) {
-            vErrors = [err4];
-          } else {
-            vErrors.push(err4);
-          }
-          errors++;
-        }
-      } else {
-        const err5 = {
-          instancePath: instancePath + '/media_url',
-          schemaPath: '#/definitions/uri/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err5];
-        } else {
-          vErrors.push(err5);
-        }
-        errors++;
-      }
-    }
-  } else {
-    const err6 = {
-      instancePath,
-      schemaPath: '#/type',
-      keyword: 'type',
-      params: { type: 'object' },
-      message: 'must be object',
-    };
-    if (vErrors === null) {
-      vErrors = [err6];
-    } else {
-      vErrors.push(err6);
-    }
-    errors++;
-  }
-  validate23.errors = vErrors;
-  return errors === 0;
-}
-const schema34 = {
-  type: 'object',
-  properties: {
-    type: { const: 'carousel' },
-    link: { $ref: '#/definitions/card:link' },
-    media_urls: { type: 'array', items: { $ref: '#/definitions/uri' } },
-  },
-  required: ['type', 'media_urls'],
-  additionalProperties: false,
-};
-function validate26(
-  data,
-  { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
-) {
-  let vErrors = null;
-  let errors = 0;
-  if (data && typeof data == 'object' && !Array.isArray(data)) {
-    if (data.type === undefined) {
-      const err0 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'type' },
-        message: "must have required property '" + 'type' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err0];
-      } else {
-        vErrors.push(err0);
-      }
-      errors++;
-    }
-    if (data.media_urls === undefined) {
-      const err1 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'media_urls' },
-        message: "must have required property '" + 'media_urls' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err1];
-      } else {
-        vErrors.push(err1);
-      }
-      errors++;
-    }
-    for (const key0 in data) {
-      if (!(key0 === 'type' || key0 === 'link' || key0 === 'media_urls')) {
-        const err2 = {
-          instancePath,
-          schemaPath: '#/additionalProperties',
-          keyword: 'additionalProperties',
-          params: { additionalProperty: key0 },
-          message: 'must NOT have additional properties',
-        };
-        if (vErrors === null) {
-          vErrors = [err2];
-        } else {
-          vErrors.push(err2);
-        }
-        errors++;
-      }
-    }
-    if (data.type !== undefined) {
-      if ('carousel' !== data.type) {
-        const err3 = {
-          instancePath: instancePath + '/type',
-          schemaPath: '#/properties/type/const',
-          keyword: 'const',
-          params: { allowedValue: 'carousel' },
-          message: 'must be equal to constant',
-        };
-        if (vErrors === null) {
-          vErrors = [err3];
-        } else {
-          vErrors.push(err3);
-        }
-        errors++;
-      }
-    }
-    if (data.link !== undefined) {
-      if (
-        !validate24(data.link, {
-          instancePath: instancePath + '/link',
-          parentData: data,
-          parentDataProperty: 'link',
-          rootData,
-        })
-      ) {
-        vErrors =
-          vErrors === null ?
-            validate24.errors
-          : vErrors.concat(validate24.errors);
-        errors = vErrors.length;
-      }
-    }
-    if (data.media_urls !== undefined) {
-      let data2 = data.media_urls;
-      if (Array.isArray(data2)) {
-        const len0 = data2.length;
-        for (let i0 = 0; i0 < len0; i0++) {
-          let data3 = data2[i0];
-          if (typeof data3 === 'string') {
-            if (!formats0(data3)) {
-              const err4 = {
-                instancePath: instancePath + '/media_urls/' + i0,
-                schemaPath: '#/definitions/uri/format',
-                keyword: 'format',
-                params: { format: 'uri' },
-                message: 'must match format "' + 'uri' + '"',
-              };
-              if (vErrors === null) {
-                vErrors = [err4];
-              } else {
-                vErrors.push(err4);
-              }
-              errors++;
-            }
-          } else {
-            const err5 = {
-              instancePath: instancePath + '/media_urls/' + i0,
-              schemaPath: '#/definitions/uri/type',
-              keyword: 'type',
-              params: { type: 'string' },
-              message: 'must be string',
-            };
-            if (vErrors === null) {
-              vErrors = [err5];
-            } else {
-              vErrors.push(err5);
-            }
-            errors++;
-          }
-        }
-      } else {
-        const err6 = {
-          instancePath: instancePath + '/media_urls',
-          schemaPath: '#/properties/media_urls/type',
-          keyword: 'type',
-          params: { type: 'array' },
-          message: 'must be array',
-        };
-        if (vErrors === null) {
-          vErrors = [err6];
-        } else {
-          vErrors.push(err6);
-        }
-        errors++;
-      }
-    }
-  } else {
-    const err7 = {
-      instancePath,
-      schemaPath: '#/type',
-      keyword: 'type',
-      params: { type: 'object' },
-      message: 'must be object',
-    };
-    if (vErrors === null) {
-      vErrors = [err7];
-    } else {
-      vErrors.push(err7);
-    }
-    errors++;
-  }
-  validate26.errors = vErrors;
-  return errors === 0;
-}
-function validate22(
-  data,
-  { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
-) {
-  let vErrors = null;
-  let errors = 0;
-  if (data && typeof data == 'object' && !Array.isArray(data)) {
-    if (data.type === undefined) {
-      const err0 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'type' },
-        message: "must have required property '" + 'type' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err0];
-      } else {
-        vErrors.push(err0);
-      }
-      errors++;
-    }
-    const tag0 = data.type;
-    if (typeof tag0 == 'string') {
-      if (tag0 === 'single') {
-        if (
-          !validate23(data, {
-            instancePath,
-            parentData,
-            parentDataProperty,
-            rootData,
-          })
-        ) {
-          vErrors =
-            vErrors === null ?
-              validate23.errors
-            : vErrors.concat(validate23.errors);
-          errors = vErrors.length;
-        }
-      } else if (tag0 === 'carousel') {
-        if (
-          !validate26(data, {
-            instancePath,
-            parentData,
-            parentDataProperty,
-            rootData,
-          })
-        ) {
-          vErrors =
-            vErrors === null ?
-              validate26.errors
-            : vErrors.concat(validate26.errors);
-          errors = vErrors.length;
-        }
-      } else {
-        const err1 = {
-          instancePath,
-          schemaPath: '#/discriminator',
-          keyword: 'discriminator',
-          params: { error: 'mapping', tag: 'type', tagValue: tag0 },
-          message: 'value of tag "type" must be in oneOf',
-        };
-        if (vErrors === null) {
-          vErrors = [err1];
-        } else {
-          vErrors.push(err1);
-        }
-        errors++;
-      }
-    } else {
-      const err2 = {
-        instancePath,
-        schemaPath: '#/discriminator',
-        keyword: 'discriminator',
-        params: { error: 'tag', tag: 'type', tagValue: tag0 },
-        message: 'tag "type" must be string',
-      };
-      if (vErrors === null) {
-        vErrors = [err2];
-      } else {
-        vErrors.push(err2);
-      }
-      errors++;
-    }
-  } else {
-    const err3 = {
-      instancePath,
-      schemaPath: '#/type',
-      keyword: 'type',
-      params: { type: 'object' },
-      message: 'must be object',
-    };
-    if (vErrors === null) {
-      vErrors = [err3];
-    } else {
-      vErrors.push(err3);
-    }
-    errors++;
-  }
-  validate22.errors = vErrors;
-  return errors === 0;
-}
-const schema36 = {
-  type: 'object',
-  oneOf: [
     { $ref: '#/definitions/media:photo' },
     { $ref: '#/definitions/media:video' },
   ],
   required: ['type'],
   discriminator: { propertyName: 'type' },
 };
-const schema37 = {
+const schema28 = {
   type: 'object',
   properties: { type: { const: 'photo' }, url: { $ref: '#/definitions/uri' } },
   required: ['type', 'url'],
   additionalProperties: false,
 };
-function validate32(
+function validate23(
   data,
   { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
 ) {
@@ -2125,10 +1430,10 @@ function validate32(
     }
     errors++;
   }
-  validate32.errors = vErrors;
+  validate23.errors = vErrors;
   return errors === 0;
 }
-const schema39 = {
+const schema30 = {
   type: 'object',
   properties: {
     type: { const: 'video' },
@@ -2137,7 +1442,7 @@ const schema39 = {
   required: ['type', 'thumbnail'],
   additionalProperties: false,
 };
-function validate33(
+function validate24(
   data,
   { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
 ) {
@@ -2257,10 +1562,10 @@ function validate33(
     }
     errors++;
   }
-  validate33.errors = vErrors;
+  validate24.errors = vErrors;
   return errors === 0;
 }
-function validate31(
+function validate22(
   data,
   { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
 ) {
@@ -2286,7 +1591,7 @@ function validate31(
     if (typeof tag0 == 'string') {
       if (tag0 === 'photo') {
         if (
-          !validate32(data, {
+          !validate23(data, {
             instancePath,
             parentData,
             parentDataProperty,
@@ -2295,13 +1600,13 @@ function validate31(
         ) {
           vErrors =
             vErrors === null ?
-              validate32.errors
-            : vErrors.concat(validate32.errors);
+              validate23.errors
+            : vErrors.concat(validate23.errors);
           errors = vErrors.length;
         }
       } else if (tag0 === 'video') {
         if (
-          !validate33(data, {
+          !validate24(data, {
             instancePath,
             parentData,
             parentDataProperty,
@@ -2310,8 +1615,8 @@ function validate31(
         ) {
           vErrors =
             vErrors === null ?
-              validate33.errors
-            : vErrors.concat(validate33.errors);
+              validate24.errors
+            : vErrors.concat(validate24.errors);
           errors = vErrors.length;
         }
       } else {
@@ -2359,7 +1664,7 @@ function validate31(
     }
     errors++;
   }
-  validate31.errors = vErrors;
+  validate22.errors = vErrors;
   return errors === 0;
 }
 function validate11(
@@ -2452,7 +1757,6 @@ function validate11(
           key0 === 'saved_at' ||
           key0 === 'author' ||
           key0 === 'text' ||
-          key0 === 'card' ||
           key0 === 'media'
         )
       ) {
@@ -2607,39 +1911,23 @@ function validate11(
         errors++;
       }
     }
-    if (data.card !== undefined) {
-      if (
-        !validate22(data.card, {
-          instancePath: instancePath + '/card',
-          parentData: data,
-          parentDataProperty: 'card',
-          rootData,
-        })
-      ) {
-        vErrors =
-          vErrors === null ?
-            validate22.errors
-          : vErrors.concat(validate22.errors);
-        errors = vErrors.length;
-      }
-    }
     if (data.media !== undefined) {
-      let data7 = data.media;
-      if (Array.isArray(data7)) {
-        const len1 = data7.length;
+      let data6 = data.media;
+      if (Array.isArray(data6)) {
+        const len1 = data6.length;
         for (let i1 = 0; i1 < len1; i1++) {
           if (
-            !validate31(data7[i1], {
+            !validate22(data6[i1], {
               instancePath: instancePath + '/media/' + i1,
-              parentData: data7,
+              parentData: data6,
               parentDataProperty: i1,
               rootData,
             })
           ) {
             vErrors =
               vErrors === null ?
-                validate31.errors
-              : vErrors.concat(validate31.errors);
+                validate22.errors
+              : vErrors.concat(validate22.errors);
             errors = vErrors.length;
           }
         }

--- a/src/validate-json/validate-tweets.js
+++ b/src/validate-json/validate-tweets.js
@@ -15,7 +15,6 @@ const schema11 = {
         saved_at: { type: 'integer' },
         author: { $ref: '#/definitions/user' },
         text: { type: 'array', items: { $ref: '#/definitions/entity' } },
-        card: { $ref: '#/definitions/card' },
         media: { type: 'array', items: { $ref: '#/definitions/media' } },
       },
       required: ['id', 'created_at', 'saved_at', 'author', 'text'],
@@ -121,46 +120,6 @@ const schema11 = {
       required: ['type', 'thumbnail'],
       additionalProperties: false,
     },
-    card: {
-      type: 'object',
-      oneOf: [
-        { $ref: '#/definitions/card:single' },
-        { $ref: '#/definitions/card:carousel' },
-      ],
-      required: ['type'],
-      discriminator: { propertyName: 'type' },
-    },
-    'card:link': {
-      type: 'object',
-      properties: {
-        url: { $ref: '#/definitions/uri' },
-        expanded_url: { $ref: '#/definitions/uri' },
-        decoded_url: { $ref: '#/definitions/iri' },
-        title: { type: 'string' },
-      },
-      required: ['url', 'expanded_url', 'decoded_url'],
-      additionalProperties: false,
-    },
-    'card:single': {
-      type: 'object',
-      properties: {
-        type: { const: 'single' },
-        link: { $ref: '#/definitions/card:link' },
-        media_url: { $ref: '#/definitions/uri' },
-      },
-      required: ['type', 'media_url'],
-      additionalProperties: false,
-    },
-    'card:carousel': {
-      type: 'object',
-      properties: {
-        type: { const: 'carousel' },
-        link: { $ref: '#/definitions/card:link' },
-        media_urls: { type: 'array', items: { $ref: '#/definitions/uri' } },
-      },
-      required: ['type', 'media_urls'],
-      additionalProperties: false,
-    },
   },
 };
 const schema12 = {
@@ -171,7 +130,6 @@ const schema12 = {
     saved_at: { type: 'integer' },
     author: { $ref: '#/definitions/user' },
     text: { type: 'array', items: { $ref: '#/definitions/entity' } },
-    card: { $ref: '#/definitions/card' },
     media: { type: 'array', items: { $ref: '#/definitions/media' } },
   },
   required: ['id', 'created_at', 'saved_at', 'author', 'text'],
@@ -1341,672 +1299,19 @@ function validate14(
 const schema27 = {
   type: 'object',
   oneOf: [
-    { $ref: '#/definitions/card:single' },
-    { $ref: '#/definitions/card:carousel' },
-  ],
-  required: ['type'],
-  discriminator: { propertyName: 'type' },
-};
-const schema28 = {
-  type: 'object',
-  properties: {
-    type: { const: 'single' },
-    link: { $ref: '#/definitions/card:link' },
-    media_url: { $ref: '#/definitions/uri' },
-  },
-  required: ['type', 'media_url'],
-  additionalProperties: false,
-};
-const schema29 = {
-  type: 'object',
-  properties: {
-    url: { $ref: '#/definitions/uri' },
-    expanded_url: { $ref: '#/definitions/uri' },
-    decoded_url: { $ref: '#/definitions/iri' },
-    title: { type: 'string' },
-  },
-  required: ['url', 'expanded_url', 'decoded_url'],
-  additionalProperties: false,
-};
-function validate24(
-  data,
-  { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
-) {
-  let vErrors = null;
-  let errors = 0;
-  if (data && typeof data == 'object' && !Array.isArray(data)) {
-    if (data.url === undefined) {
-      const err0 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'url' },
-        message: "must have required property '" + 'url' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err0];
-      } else {
-        vErrors.push(err0);
-      }
-      errors++;
-    }
-    if (data.expanded_url === undefined) {
-      const err1 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'expanded_url' },
-        message: "must have required property '" + 'expanded_url' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err1];
-      } else {
-        vErrors.push(err1);
-      }
-      errors++;
-    }
-    if (data.decoded_url === undefined) {
-      const err2 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'decoded_url' },
-        message: "must have required property '" + 'decoded_url' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err2];
-      } else {
-        vErrors.push(err2);
-      }
-      errors++;
-    }
-    for (const key0 in data) {
-      if (
-        !(
-          key0 === 'url' ||
-          key0 === 'expanded_url' ||
-          key0 === 'decoded_url' ||
-          key0 === 'title'
-        )
-      ) {
-        const err3 = {
-          instancePath,
-          schemaPath: '#/additionalProperties',
-          keyword: 'additionalProperties',
-          params: { additionalProperty: key0 },
-          message: 'must NOT have additional properties',
-        };
-        if (vErrors === null) {
-          vErrors = [err3];
-        } else {
-          vErrors.push(err3);
-        }
-        errors++;
-      }
-    }
-    if (data.url !== undefined) {
-      let data0 = data.url;
-      if (typeof data0 === 'string') {
-        if (!formats0(data0)) {
-          const err4 = {
-            instancePath: instancePath + '/url',
-            schemaPath: '#/definitions/uri/format',
-            keyword: 'format',
-            params: { format: 'uri' },
-            message: 'must match format "' + 'uri' + '"',
-          };
-          if (vErrors === null) {
-            vErrors = [err4];
-          } else {
-            vErrors.push(err4);
-          }
-          errors++;
-        }
-      } else {
-        const err5 = {
-          instancePath: instancePath + '/url',
-          schemaPath: '#/definitions/uri/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err5];
-        } else {
-          vErrors.push(err5);
-        }
-        errors++;
-      }
-    }
-    if (data.expanded_url !== undefined) {
-      let data1 = data.expanded_url;
-      if (typeof data1 === 'string') {
-        if (!formats0(data1)) {
-          const err6 = {
-            instancePath: instancePath + '/expanded_url',
-            schemaPath: '#/definitions/uri/format',
-            keyword: 'format',
-            params: { format: 'uri' },
-            message: 'must match format "' + 'uri' + '"',
-          };
-          if (vErrors === null) {
-            vErrors = [err6];
-          } else {
-            vErrors.push(err6);
-          }
-          errors++;
-        }
-      } else {
-        const err7 = {
-          instancePath: instancePath + '/expanded_url',
-          schemaPath: '#/definitions/uri/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err7];
-        } else {
-          vErrors.push(err7);
-        }
-        errors++;
-      }
-    }
-    if (data.decoded_url !== undefined) {
-      let data2 = data.decoded_url;
-      if (typeof data2 === 'string') {
-        if (!formats4(data2)) {
-          const err8 = {
-            instancePath: instancePath + '/decoded_url',
-            schemaPath: '#/definitions/iri/format',
-            keyword: 'format',
-            params: { format: 'iri' },
-            message: 'must match format "' + 'iri' + '"',
-          };
-          if (vErrors === null) {
-            vErrors = [err8];
-          } else {
-            vErrors.push(err8);
-          }
-          errors++;
-        }
-      } else {
-        const err9 = {
-          instancePath: instancePath + '/decoded_url',
-          schemaPath: '#/definitions/iri/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err9];
-        } else {
-          vErrors.push(err9);
-        }
-        errors++;
-      }
-    }
-    if (data.title !== undefined) {
-      if (typeof data.title !== 'string') {
-        const err10 = {
-          instancePath: instancePath + '/title',
-          schemaPath: '#/properties/title/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err10];
-        } else {
-          vErrors.push(err10);
-        }
-        errors++;
-      }
-    }
-  } else {
-    const err11 = {
-      instancePath,
-      schemaPath: '#/type',
-      keyword: 'type',
-      params: { type: 'object' },
-      message: 'must be object',
-    };
-    if (vErrors === null) {
-      vErrors = [err11];
-    } else {
-      vErrors.push(err11);
-    }
-    errors++;
-  }
-  validate24.errors = vErrors;
-  return errors === 0;
-}
-function validate23(
-  data,
-  { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
-) {
-  let vErrors = null;
-  let errors = 0;
-  if (data && typeof data == 'object' && !Array.isArray(data)) {
-    if (data.type === undefined) {
-      const err0 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'type' },
-        message: "must have required property '" + 'type' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err0];
-      } else {
-        vErrors.push(err0);
-      }
-      errors++;
-    }
-    if (data.media_url === undefined) {
-      const err1 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'media_url' },
-        message: "must have required property '" + 'media_url' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err1];
-      } else {
-        vErrors.push(err1);
-      }
-      errors++;
-    }
-    for (const key0 in data) {
-      if (!(key0 === 'type' || key0 === 'link' || key0 === 'media_url')) {
-        const err2 = {
-          instancePath,
-          schemaPath: '#/additionalProperties',
-          keyword: 'additionalProperties',
-          params: { additionalProperty: key0 },
-          message: 'must NOT have additional properties',
-        };
-        if (vErrors === null) {
-          vErrors = [err2];
-        } else {
-          vErrors.push(err2);
-        }
-        errors++;
-      }
-    }
-    if (data.type !== undefined) {
-      if ('single' !== data.type) {
-        const err3 = {
-          instancePath: instancePath + '/type',
-          schemaPath: '#/properties/type/const',
-          keyword: 'const',
-          params: { allowedValue: 'single' },
-          message: 'must be equal to constant',
-        };
-        if (vErrors === null) {
-          vErrors = [err3];
-        } else {
-          vErrors.push(err3);
-        }
-        errors++;
-      }
-    }
-    if (data.link !== undefined) {
-      if (
-        !validate24(data.link, {
-          instancePath: instancePath + '/link',
-          parentData: data,
-          parentDataProperty: 'link',
-          rootData,
-        })
-      ) {
-        vErrors =
-          vErrors === null ?
-            validate24.errors
-          : vErrors.concat(validate24.errors);
-        errors = vErrors.length;
-      }
-    }
-    if (data.media_url !== undefined) {
-      let data2 = data.media_url;
-      if (typeof data2 === 'string') {
-        if (!formats0(data2)) {
-          const err4 = {
-            instancePath: instancePath + '/media_url',
-            schemaPath: '#/definitions/uri/format',
-            keyword: 'format',
-            params: { format: 'uri' },
-            message: 'must match format "' + 'uri' + '"',
-          };
-          if (vErrors === null) {
-            vErrors = [err4];
-          } else {
-            vErrors.push(err4);
-          }
-          errors++;
-        }
-      } else {
-        const err5 = {
-          instancePath: instancePath + '/media_url',
-          schemaPath: '#/definitions/uri/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
-        };
-        if (vErrors === null) {
-          vErrors = [err5];
-        } else {
-          vErrors.push(err5);
-        }
-        errors++;
-      }
-    }
-  } else {
-    const err6 = {
-      instancePath,
-      schemaPath: '#/type',
-      keyword: 'type',
-      params: { type: 'object' },
-      message: 'must be object',
-    };
-    if (vErrors === null) {
-      vErrors = [err6];
-    } else {
-      vErrors.push(err6);
-    }
-    errors++;
-  }
-  validate23.errors = vErrors;
-  return errors === 0;
-}
-const schema34 = {
-  type: 'object',
-  properties: {
-    type: { const: 'carousel' },
-    link: { $ref: '#/definitions/card:link' },
-    media_urls: { type: 'array', items: { $ref: '#/definitions/uri' } },
-  },
-  required: ['type', 'media_urls'],
-  additionalProperties: false,
-};
-function validate26(
-  data,
-  { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
-) {
-  let vErrors = null;
-  let errors = 0;
-  if (data && typeof data == 'object' && !Array.isArray(data)) {
-    if (data.type === undefined) {
-      const err0 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'type' },
-        message: "must have required property '" + 'type' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err0];
-      } else {
-        vErrors.push(err0);
-      }
-      errors++;
-    }
-    if (data.media_urls === undefined) {
-      const err1 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'media_urls' },
-        message: "must have required property '" + 'media_urls' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err1];
-      } else {
-        vErrors.push(err1);
-      }
-      errors++;
-    }
-    for (const key0 in data) {
-      if (!(key0 === 'type' || key0 === 'link' || key0 === 'media_urls')) {
-        const err2 = {
-          instancePath,
-          schemaPath: '#/additionalProperties',
-          keyword: 'additionalProperties',
-          params: { additionalProperty: key0 },
-          message: 'must NOT have additional properties',
-        };
-        if (vErrors === null) {
-          vErrors = [err2];
-        } else {
-          vErrors.push(err2);
-        }
-        errors++;
-      }
-    }
-    if (data.type !== undefined) {
-      if ('carousel' !== data.type) {
-        const err3 = {
-          instancePath: instancePath + '/type',
-          schemaPath: '#/properties/type/const',
-          keyword: 'const',
-          params: { allowedValue: 'carousel' },
-          message: 'must be equal to constant',
-        };
-        if (vErrors === null) {
-          vErrors = [err3];
-        } else {
-          vErrors.push(err3);
-        }
-        errors++;
-      }
-    }
-    if (data.link !== undefined) {
-      if (
-        !validate24(data.link, {
-          instancePath: instancePath + '/link',
-          parentData: data,
-          parentDataProperty: 'link',
-          rootData,
-        })
-      ) {
-        vErrors =
-          vErrors === null ?
-            validate24.errors
-          : vErrors.concat(validate24.errors);
-        errors = vErrors.length;
-      }
-    }
-    if (data.media_urls !== undefined) {
-      let data2 = data.media_urls;
-      if (Array.isArray(data2)) {
-        const len0 = data2.length;
-        for (let i0 = 0; i0 < len0; i0++) {
-          let data3 = data2[i0];
-          if (typeof data3 === 'string') {
-            if (!formats0(data3)) {
-              const err4 = {
-                instancePath: instancePath + '/media_urls/' + i0,
-                schemaPath: '#/definitions/uri/format',
-                keyword: 'format',
-                params: { format: 'uri' },
-                message: 'must match format "' + 'uri' + '"',
-              };
-              if (vErrors === null) {
-                vErrors = [err4];
-              } else {
-                vErrors.push(err4);
-              }
-              errors++;
-            }
-          } else {
-            const err5 = {
-              instancePath: instancePath + '/media_urls/' + i0,
-              schemaPath: '#/definitions/uri/type',
-              keyword: 'type',
-              params: { type: 'string' },
-              message: 'must be string',
-            };
-            if (vErrors === null) {
-              vErrors = [err5];
-            } else {
-              vErrors.push(err5);
-            }
-            errors++;
-          }
-        }
-      } else {
-        const err6 = {
-          instancePath: instancePath + '/media_urls',
-          schemaPath: '#/properties/media_urls/type',
-          keyword: 'type',
-          params: { type: 'array' },
-          message: 'must be array',
-        };
-        if (vErrors === null) {
-          vErrors = [err6];
-        } else {
-          vErrors.push(err6);
-        }
-        errors++;
-      }
-    }
-  } else {
-    const err7 = {
-      instancePath,
-      schemaPath: '#/type',
-      keyword: 'type',
-      params: { type: 'object' },
-      message: 'must be object',
-    };
-    if (vErrors === null) {
-      vErrors = [err7];
-    } else {
-      vErrors.push(err7);
-    }
-    errors++;
-  }
-  validate26.errors = vErrors;
-  return errors === 0;
-}
-function validate22(
-  data,
-  { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
-) {
-  let vErrors = null;
-  let errors = 0;
-  if (data && typeof data == 'object' && !Array.isArray(data)) {
-    if (data.type === undefined) {
-      const err0 = {
-        instancePath,
-        schemaPath: '#/required',
-        keyword: 'required',
-        params: { missingProperty: 'type' },
-        message: "must have required property '" + 'type' + "'",
-      };
-      if (vErrors === null) {
-        vErrors = [err0];
-      } else {
-        vErrors.push(err0);
-      }
-      errors++;
-    }
-    const tag0 = data.type;
-    if (typeof tag0 == 'string') {
-      if (tag0 === 'single') {
-        if (
-          !validate23(data, {
-            instancePath,
-            parentData,
-            parentDataProperty,
-            rootData,
-          })
-        ) {
-          vErrors =
-            vErrors === null ?
-              validate23.errors
-            : vErrors.concat(validate23.errors);
-          errors = vErrors.length;
-        }
-      } else if (tag0 === 'carousel') {
-        if (
-          !validate26(data, {
-            instancePath,
-            parentData,
-            parentDataProperty,
-            rootData,
-          })
-        ) {
-          vErrors =
-            vErrors === null ?
-              validate26.errors
-            : vErrors.concat(validate26.errors);
-          errors = vErrors.length;
-        }
-      } else {
-        const err1 = {
-          instancePath,
-          schemaPath: '#/discriminator',
-          keyword: 'discriminator',
-          params: { error: 'mapping', tag: 'type', tagValue: tag0 },
-          message: 'value of tag "type" must be in oneOf',
-        };
-        if (vErrors === null) {
-          vErrors = [err1];
-        } else {
-          vErrors.push(err1);
-        }
-        errors++;
-      }
-    } else {
-      const err2 = {
-        instancePath,
-        schemaPath: '#/discriminator',
-        keyword: 'discriminator',
-        params: { error: 'tag', tag: 'type', tagValue: tag0 },
-        message: 'tag "type" must be string',
-      };
-      if (vErrors === null) {
-        vErrors = [err2];
-      } else {
-        vErrors.push(err2);
-      }
-      errors++;
-    }
-  } else {
-    const err3 = {
-      instancePath,
-      schemaPath: '#/type',
-      keyword: 'type',
-      params: { type: 'object' },
-      message: 'must be object',
-    };
-    if (vErrors === null) {
-      vErrors = [err3];
-    } else {
-      vErrors.push(err3);
-    }
-    errors++;
-  }
-  validate22.errors = vErrors;
-  return errors === 0;
-}
-const schema36 = {
-  type: 'object',
-  oneOf: [
     { $ref: '#/definitions/media:photo' },
     { $ref: '#/definitions/media:video' },
   ],
   required: ['type'],
   discriminator: { propertyName: 'type' },
 };
-const schema37 = {
+const schema28 = {
   type: 'object',
   properties: { type: { const: 'photo' }, url: { $ref: '#/definitions/uri' } },
   required: ['type', 'url'],
   additionalProperties: false,
 };
-function validate32(
+function validate23(
   data,
   { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
 ) {
@@ -2126,10 +1431,10 @@ function validate32(
     }
     errors++;
   }
-  validate32.errors = vErrors;
+  validate23.errors = vErrors;
   return errors === 0;
 }
-const schema39 = {
+const schema30 = {
   type: 'object',
   properties: {
     type: { const: 'video' },
@@ -2138,7 +1443,7 @@ const schema39 = {
   required: ['type', 'thumbnail'],
   additionalProperties: false,
 };
-function validate33(
+function validate24(
   data,
   { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
 ) {
@@ -2258,10 +1563,10 @@ function validate33(
     }
     errors++;
   }
-  validate33.errors = vErrors;
+  validate24.errors = vErrors;
   return errors === 0;
 }
-function validate31(
+function validate22(
   data,
   { instancePath = '', parentData, parentDataProperty, rootData = data } = {},
 ) {
@@ -2287,7 +1592,7 @@ function validate31(
     if (typeof tag0 == 'string') {
       if (tag0 === 'photo') {
         if (
-          !validate32(data, {
+          !validate23(data, {
             instancePath,
             parentData,
             parentDataProperty,
@@ -2296,13 +1601,13 @@ function validate31(
         ) {
           vErrors =
             vErrors === null ?
-              validate32.errors
-            : vErrors.concat(validate32.errors);
+              validate23.errors
+            : vErrors.concat(validate23.errors);
           errors = vErrors.length;
         }
       } else if (tag0 === 'video') {
         if (
-          !validate33(data, {
+          !validate24(data, {
             instancePath,
             parentData,
             parentDataProperty,
@@ -2311,8 +1616,8 @@ function validate31(
         ) {
           vErrors =
             vErrors === null ?
-              validate33.errors
-            : vErrors.concat(validate33.errors);
+              validate24.errors
+            : vErrors.concat(validate24.errors);
           errors = vErrors.length;
         }
       } else {
@@ -2360,7 +1665,7 @@ function validate31(
     }
     errors++;
   }
-  validate31.errors = vErrors;
+  validate22.errors = vErrors;
   return errors === 0;
 }
 function validate11(
@@ -2453,7 +1758,6 @@ function validate11(
           key0 === 'saved_at' ||
           key0 === 'author' ||
           key0 === 'text' ||
-          key0 === 'card' ||
           key0 === 'media'
         )
       ) {
@@ -2608,39 +1912,23 @@ function validate11(
         errors++;
       }
     }
-    if (data.card !== undefined) {
-      if (
-        !validate22(data.card, {
-          instancePath: instancePath + '/card',
-          parentData: data,
-          parentDataProperty: 'card',
-          rootData,
-        })
-      ) {
-        vErrors =
-          vErrors === null ?
-            validate22.errors
-          : vErrors.concat(validate22.errors);
-        errors = vErrors.length;
-      }
-    }
     if (data.media !== undefined) {
-      let data7 = data.media;
-      if (Array.isArray(data7)) {
-        const len1 = data7.length;
+      let data6 = data.media;
+      if (Array.isArray(data6)) {
+        const len1 = data6.length;
         for (let i1 = 0; i1 < len1; i1++) {
           if (
-            !validate31(data7[i1], {
+            !validate22(data6[i1], {
               instancePath: instancePath + '/media/' + i1,
-              parentData: data7,
+              parentData: data6,
               parentDataProperty: i1,
               rootData,
             })
           ) {
             vErrors =
               vErrors === null ?
-                validate31.errors
-              : vErrors.concat(validate31.errors);
+                validate22.errors
+              : vErrors.concat(validate22.errors);
             errors = vErrors.length;
           }
         }


### PR DESCRIPTION
# Parse Tweet.card as TweetEntityURL

Parse a cart in a tweet as a TweetEntityURL.

Delete `Tweet.card`.

Add `GetURLTitle` messages to get the title of the URL in the card.