### PR TITLE
Update Domain

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -24,9 +24,9 @@ if (process.env.NODE_ENV !== 'production') {
     browser.cookies.set({
       name: 'auth_token',
       value: process.env.TWITTER_AUTH_TOKEN_COOKIE,
-      domain: '.twitter.com',
+      domain: '.x.com',
       path: '/',
-      url: 'https://twitter.com',
+      url: 'https://x.com',
     });
   }
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,7 +1,7 @@
 import { defaultTimezone } from './datetime';
 import { SortOrder, TweetSort } from './tweet/types';
 
-export const hostnames = ['twitter.com', 'x.com'] as const;
+export const hostnames = ['x.com', 'twitter.com'] as const;
 
 export type Hostname = (typeof hostnames)[number];
 
@@ -20,7 +20,7 @@ export interface Settings {
 
 export const defaultSettings = (): Settings => {
   return {
-    hostname: 'twitter.com',
+    hostname: 'x.com',
     timezone: defaultTimezone(),
     datetimeFormat: 'YYYY/MM/DD HH:mm:ss',
     tweetSort: {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,11 @@
     "tabs"
   ],
   "__prod__host_permissions": ["https://*/*"],
-  "__dev__host_permissions": ["https://twitter.com/*", "https://*/*"],
+  "__dev__host_permissions": [
+    "https://twitter.com/*",
+    "https://x.com/*",
+    "https://*/*"
+  ],
 
   "__chrome__background": {
     "service_worker": "background.js",
@@ -38,7 +42,7 @@
 
   "content_scripts": [
     {
-      "matches": ["https://twitter.com/*"],
+      "matches": ["https://twitter.com/*", "https://x.com/*"],
       "run_at": "document_start",
       "js": ["content-twitter.js"],
       "css": ["content-twitter.css"]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -48,7 +48,7 @@
       "css": ["content-twitter.css"]
     },
     {
-      "matches": ["https://scrapbox.io/*"],
+      "matches": ["https://scrapbox.io/*", "https://cosen.se/*"],
       "run_at": "document_start",
       "js": ["content-scrapbox.js"],
       "css": ["content-scrapbox.css"]


### PR DESCRIPTION
# Update Domain

## twitter.com -> x.com

After 2024-05-17, twitter.com is redirect to x.com.

Add x.com to manifest.json.

Make x.com default hostname.

## scrapbox.io -> cosen.se

The service name is changed from "Scrapbox" to "Helpfeel Cosense" on 2024-05-21.
[【サービス名変更のお知らせ】「Scrapbox」は「Helpfeel Cosense（ヘルプフィール コセンス）」に変わります](https://prtimes.jp/main/html/rd/p/000000323.000027275.html)

Add cosen.se to manifest.json.