### PR TITLE
Fix parsing quote tweets that have no text

### DIFF
--- a/src/content-twitter/lib/insert-react-root.ts
+++ b/src/content-twitter/lib/insert-react-root.ts
@@ -1,6 +1,7 @@
 import { getElement, getElements, getNode } from '~/lib/dom';
 import { Logger, logger as defaultLogger } from '~/lib/logger';
 import { TweetID } from '~/lib/tweet/types';
+import { isPromotionTweet } from './tweet';
 
 export interface InsertReactRootResult {
   tweetID: TweetID;
@@ -151,8 +152,4 @@ const createRootDiv = (
   root.classList.add('scrapbox-copy-tweets');
   root.setAttribute('tweet-id', tweetID);
   return root;
-};
-
-const isPromotionTweet = (article: Element): boolean => {
-  return getElement('self::article//a/time', article) === null;
 };

--- a/src/content-twitter/lib/parse-tweet-text.ts
+++ b/src/content-twitter/lib/parse-tweet-text.ts
@@ -14,6 +14,7 @@ import {
   TweetEntityURL,
 } from '~/lib/tweet/types';
 import { decodeURL, formatTCoURL } from '~/lib/url';
+import { isInQuotedTweet } from './tweet';
 
 export const parseTweetText = async (
   tweet: Element,
@@ -23,6 +24,10 @@ export const parseTweetText = async (
   logger.debug('Text <div data-testid="tweetText">', element);
   if (element === null) {
     logger.warn('<div data-testid="tweetText"> is not found');
+    return [];
+  }
+  if (isInQuotedTweet(element)) {
+    logger.debug('<div data-testid="tweetText"> is in quoted tweet');
     return [];
   }
   const result: TweetEntity[] = [];

--- a/src/content-twitter/lib/parse-tweet-text.ts
+++ b/src/content-twitter/lib/parse-tweet-text.ts
@@ -23,7 +23,7 @@ export const parseTweetText = async (
   const element = getElement('.//div[@data-testid="tweetText"]', tweet);
   logger.debug('Text <div data-testid="tweetText">', element);
   if (element === null) {
-    logger.warn('<div data-testid="tweetText"> is not found');
+    logger.debug('<div data-testid="tweetText"> is not in tweet');
     return [];
   }
   if (isInQuotedTweet(element)) {

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -20,6 +20,7 @@ import {
 import { decodeURL, formatTwimgURL, isTCoURL } from '~/lib/url';
 import { ParseTweetError } from './error';
 import { parseTweetText } from './parse-tweet-text';
+import { isInQuotedTweet } from './tweet';
 
 export const parseTweet = async (
   id: TweetID,
@@ -68,10 +69,6 @@ export const parseTweet = async (
     result.media = media;
   }
   return result;
-};
-
-const isInQuotedTweet = (element: Element): boolean => {
-  return getElement('ancestor::div[@role="link"]', element) !== null;
 };
 
 const parseTimestamp = (tweet: Element, logger: Logger): number | null => {

--- a/src/content-twitter/lib/tweet.ts
+++ b/src/content-twitter/lib/tweet.ts
@@ -1,0 +1,9 @@
+import { getElement } from '~/lib/dom';
+
+export const isPromotionTweet = (article: Element): boolean => {
+  return getElement('self::article//a/time', article) === null;
+};
+
+export const isInQuotedTweet = (element: Element): boolean => {
+  return getElement('ancestor::div[@role="link"]', element) !== null;
+};


### PR DESCRIPTION
# Fix parsing quote tweets that have no text

If the quote Tweet did not have text, the text of the quoted Tweet was gotten instead.

If there is no text in a tweet, it is no longer considered a warning.