### PR TITLE
Fix to Match Empty Placeholder

### DIFF
--- a/src/lib/tweet/tweet-template.ts
+++ b/src/lib/tweet/tweet-template.ts
@@ -176,7 +176,7 @@ const parsePlaceholders = <Field extends string>(
   const elements: TemplateElement<Field>[] = [];
   let tail = template;
   while (tail.length > 0) {
-    const match = tail.match(/(?<!\\)\$\{(?<field>.+?)\}/);
+    const match = tail.match(/(?<!\\)\$\{(?<field>.*?)\}/);
     if (match !== null) {
       if (match.index !== 0) {
         elements.push({ type: 'text', text: tail.slice(0, match.index) });

--- a/test/tweet-template.ts
+++ b/test/tweet-template.ts
@@ -29,6 +29,12 @@ describe('tweet-template/tweet', () => {
     ];
     expect(tweetTemplateParser.tweet(template)).toStrictEqual(expected);
   });
+  test('empty_placeholder', () => {
+    const template = '${}';
+    expect(() => tweetTemplateParser.tweet(template)).toThrow(
+      UnexpectedPlaceholderError,
+    );
+  });
   test('unexpected_field', () => {
     const template = '[${tweet.url} @${user.usrname}]';
     try {

--- a/test/tweet-template.ts
+++ b/test/tweet-template.ts
@@ -29,6 +29,14 @@ describe('tweet-template/tweet', () => {
     ];
     expect(tweetTemplateParser.tweet(template)).toStrictEqual(expected);
   });
+  test('connected_placeholder', () => {
+    const template = '${tweet.url}${user.username}';
+    const expected = [
+      { type: 'placeholder', field: 'tweet.url' },
+      { type: 'placeholder', field: 'user.username' },
+    ];
+    expect(tweetTemplateParser.tweet(template)).toStrictEqual(expected);
+  });
   test('empty_placeholder', () => {
     const template = '${}';
     expect(() => tweetTemplateParser.tweet(template)).toThrow(


### PR DESCRIPTION
Fix to Match Empty Placeholder(`${}`).

Add test cases to tweet-template.

