### PR TITLE
Group TweetTemplate Selectors into an Object

### DIFF
--- a/src/app/component/settings.tsx
+++ b/src/app/component/settings.tsx
@@ -504,21 +504,9 @@ const TemplateMediaEditor: React.FC = () => {
 };
 
 const TemplateQuote: React.FC = () => {
-  const selectCurrent = React.useCallback(
-    (state: State) => selectTemplate(state, 'quote'),
-    [],
-  );
-  const selectEditing = React.useCallback(
-    (state: State) => selectEditingTemplate(state, 'quote'),
-    [],
-  );
-  const selectError = React.useCallback(
-    (state: State) => selectTemplateError(state, 'quote'),
-    [],
-  );
-  const current = useSelector(selectCurrent);
-  const editing = useSelector(selectEditing);
-  const error = useSelector(selectError, shallowEqual);
+  const current = useSelector(selectTemplate.quote);
+  const editing = useSelector(selectEditingTemplate.quote);
+  const error = useSelector(selectTemplateError.quote, shallowEqual);
   const dispatch = useDispatch();
 
   const value = editing ?? current;
@@ -720,21 +708,9 @@ type TextTemplateProps = {
 };
 
 const TextTemplate: React.FC<TextTemplateProps> = ({ type, name }) => {
-  const selectCurrent = React.useCallback(
-    (state: State) => selectTemplate(state, type),
-    [type],
-  );
-  const selectEditing = React.useCallback(
-    (state: State) => selectEditingTemplate(state, type),
-    [type],
-  );
-  const selectError = React.useCallback(
-    (state: State) => selectTemplateError(state, type),
-    [type],
-  );
-  const current = useSelector(selectCurrent);
-  const editing = useSelector(selectEditing);
-  const error = useSelector(selectError, shallowEqual);
+  const current = useSelector(selectTemplate[type]);
+  const editing = useSelector(selectEditingTemplate[type]);
+  const error = useSelector(selectTemplateError[type], shallowEqual);
   const dispatch = useDispatch();
 
   const value = editing ?? current;

--- a/src/app/store/selector.ts
+++ b/src/app/store/selector.ts
@@ -7,9 +7,10 @@ import {
 } from '~/lib/settings';
 import { type TrashboxSort, deletedTimes } from '~/lib/trashbox';
 import { tweetSortFunction } from '~/lib/tweet/sort-tweets';
-import type {
-  TextTemplateKey,
-  TweetTemplate,
+import {
+  type TextTemplateKey,
+  type TweetTemplate,
+  tweetTemplateKeys,
 } from '~/lib/tweet/tweet-template';
 import type { TweetToStringOption } from '~/lib/tweet/tweet-to-string';
 import type {
@@ -220,28 +221,47 @@ export const selectSettingsError: Readonly<SettingsErrorSelectors> =
   );
 
 // tweet-template: currnt
-export const selectTemplate = <Key extends keyof TweetTemplate>(
-  state: State,
-  key: Key,
-): TweetTemplate[Key] => {
-  return state.settings.currentTemplate[key];
+type TweetTemplateSelectors = {
+  [Key in keyof TweetTemplate]: (state: State) => TweetTemplate[Key];
 };
+
+export const selectTemplate: Readonly<TweetTemplateSelectors> =
+  tweetTemplateKeys.reduce(
+    (selectors, key) =>
+      Object.assign(selectors, {
+        [key]: (state: State) => state.settings.currentTemplate[key],
+      }),
+    {} as TweetTemplateSelectors,
+  );
 
 // tweet-template: editing
-export const selectEditingTemplate = <Key extends keyof TweetTemplate>(
-  state: State,
-  key: Key,
-): TweetTemplate[Key] | undefined => {
-  return state.settings.editingTemplate[key];
+type EditingTweetTemplateSelectors = {
+  [Key in keyof TweetTemplate]: (state: State) => Partial<TweetTemplate>[Key];
 };
 
+export const selectEditingTemplate: Readonly<EditingTweetTemplateSelectors> =
+  tweetTemplateKeys.reduce(
+    (selectors, key) =>
+      Object.assign(selectors, {
+        [key]: (state: State) => state.settings.editingTemplate[key],
+      }),
+    {} as EditingTweetTemplateSelectors,
+  );
+
 // tweet-template: error
-export const selectTemplateError = <Key extends keyof TweetTemplate>(
-  state: State,
-  key: Key,
-): string[] => {
-  return fallbackToEmptyArray(state.settings.templateErrors[key] ?? []);
+type TweetTemplateErrorsSelectors = {
+  [Key in keyof TweetTemplate]: (state: State) => string[];
 };
+
+export const selectTemplateError: Readonly<TweetTemplateErrorsSelectors> =
+  tweetTemplateKeys.reduce(
+    (selectors, key) =>
+      Object.assign(selectors, {
+        [key]: (state: State) =>
+          fallbackToEmptyArray(state.settings.templateErrors[key] ?? []),
+      }),
+    {} as TweetTemplateErrorsSelectors,
+  );
 
 // settings update trigger
 export const selectSettingsUpdateTrigger = (state: State): UpdateTrigger => {

--- a/src/app/store/selector.ts
+++ b/src/app/store/selector.ts
@@ -21,11 +21,7 @@ import type {
   TweetSort,
 } from '~/lib/tweet/types';
 import type { State } from '.';
-import type {
-  EditingTweetTemplate,
-  TemplateErrors,
-  UpdateTrigger,
-} from './settings';
+import type { TemplateErrors, UpdateTrigger } from './settings';
 
 // types
 export type EditStatus = 'none' | 'updated' | 'invalid';
@@ -311,10 +307,10 @@ const templateEntityKeys: ReadonlyArray<TextTemplateKey> = [
 ] as const;
 export const selectTemplateEntitiesEditStatus = createSelector(
   [
-    (state: State): EditingTweetTemplate => state.settings.editingTemplate,
+    (state: State): Partial<TweetTemplate> => state.settings.editingTemplate,
     (state: State): TemplateErrors => state.settings.templateErrors,
   ],
-  (editing: EditingTweetTemplate, errors: TemplateErrors): EditStatus => {
+  (editing: Partial<TweetTemplate>, errors: TemplateErrors): EditStatus => {
     const isUpdated = !templateEntityKeys.every((key) => !(key in editing));
     const hasError = !templateEntityKeys.every((key) => !(key in errors));
     return (
@@ -331,10 +327,10 @@ const templateMediaKeys: ReadonlyArray<TextTemplateKey> = [
 ] as const;
 export const selectTemplateMediaEditStatus = createSelector(
   [
-    (state: State): EditingTweetTemplate => state.settings.editingTemplate,
+    (state: State): Partial<TweetTemplate> => state.settings.editingTemplate,
     (state: State): TemplateErrors => state.settings.templateErrors,
   ],
-  (editing: EditingTweetTemplate, errors: TemplateErrors): EditStatus => {
+  (editing: Partial<TweetTemplate>, errors: TemplateErrors): EditStatus => {
     const isUpdated = !templateMediaKeys.every((key) => !(key in editing));
     const hasError = !templateMediaKeys.every((key) => !(key in errors));
     return (

--- a/src/app/store/settings.ts
+++ b/src/app/store/settings.ts
@@ -17,8 +17,6 @@ import {
 } from '~/lib/tweet/tweet-template';
 
 // state
-export type EditingSettings = Partial<Settings>;
-export type EditingTweetTemplate = Partial<TweetTemplate>;
 export type SettingsErrors = Partial<Record<keyof Settings, string[]>>;
 export type TemplateErrors = Partial<Record<keyof TweetTemplate, string[]>>;
 
@@ -26,10 +24,10 @@ export type UpdateTrigger = 'none' | 'self' | 'interrupt';
 
 export interface SettingsState {
   currentSettings: Settings;
-  editingSettings: EditingSettings;
+  editingSettings: Partial<Settings>;
   settingsErrors: SettingsErrors;
   currentTemplate: TweetTemplate;
-  editingTemplate: EditingTweetTemplate;
+  editingTemplate: Partial<TweetTemplate>;
   templateErrors: TemplateErrors;
   updateTrigger: UpdateTrigger;
 }
@@ -117,8 +115,8 @@ const settings = createSlice({
     updateByInterrupt(
       state: SettingsState,
       action: PayloadAction<{
-        settings?: EditingSettings;
-        template?: EditingTweetTemplate;
+        settings?: Partial<Settings>;
+        template?: Partial<TweetTemplate>;
       }>,
     ): void {
       // update settings
@@ -170,8 +168,8 @@ export const settingsStorageListener = (
   dispatch: Dispatch,
 ): void => {
   // settings & tweetTemplate
-  const settings: EditingSettings = args.settings || {};
-  const template: EditingTweetTemplate = args.tweetTemplate || {};
+  const settings: Partial<Settings> = args.settings || {};
+  const template: Partial<TweetTemplate> = args.tweetTemplate || {};
   const update = {
     ...(Object.keys(settings).length > 0 && { settings }),
     ...(Object.keys(template).length > 0 && { template }),


### PR DESCRIPTION
Group TweetTemplate Selectors into an Object.

Replace `EditingSettings` with `Partial<Settings>`.

Replace `EditingTweetTemplate` with `Partial<TweetTemplate>`.