### PR TITLE
Add Type Guards for @types/webextension-polifill update

### DIFF
--- a/src/content-twitter/lib/parse-tweet-text.ts
+++ b/src/content-twitter/lib/parse-tweet-text.ts
@@ -1,9 +1,9 @@
 import browser from 'webextension-polyfill';
 import { getElement, getNode, isHTMLElement } from '~/lib/dom';
 import { type Logger, logger as defaultLogger } from '~/lib/logger';
-import type {
-  ExpandTCoURLRequestMessage,
-  ExpandTCoURLResultMessage,
+import {
+  type ExpandTCoURLRequestMessage,
+  isExpandTCoURLResultMessage,
 } from '~/lib/message';
 import type {
   TweetEntity,
@@ -126,9 +126,9 @@ const parseEntityURL = async (
   logger.debug('Request to expand t.co URL', request);
   const { expandedURL, title } = await browser.runtime
     .sendMessage(request)
-    .then((response: ExpandTCoURLResultMessage) => {
+    .then((response: unknown) => {
       logger.debug('Response to request', response);
-      if (response?.type === 'ExpandTCoURL/Result') {
+      if (isExpandTCoURLResultMessage(response)) {
         if (response?.ok) {
           const { expandedURL, title } = response;
           return { expandedURL, title };

--- a/src/content-twitter/lib/parse-tweet.ts
+++ b/src/content-twitter/lib/parse-tweet.ts
@@ -1,13 +1,13 @@
 import browser from 'webextension-polyfill';
 import { getElement, getElements, getNode, getNodes } from '~/lib/dom';
-import { Logger, logger as defaultLogger } from '~/lib/logger';
+import { type Logger, logger as defaultLogger } from '~/lib/logger';
 import {
-  ExpandTCoURLRequestMessage,
-  ExpandTCoURLResultMessage,
-  GetURLTitleRequestMessage,
-  GetURLTitleResultMessage,
+  type ExpandTCoURLRequestMessage,
+  type GetURLTitleRequestMessage,
+  isExpandTCoURLResultMessage,
+  isGetURLTitleResultMessage,
 } from '~/lib/message';
-import {
+import type {
   Media,
   MediaPhoto,
   MediaVideo,
@@ -265,10 +265,10 @@ const toEntityURL = async (
     };
     const title = await browser.runtime
       .sendMessage(request)
-      .then((response: GetURLTitleResultMessage) => {
+      .then((response: unknown) => {
         logger.debug('Response to request', response);
-        if (response?.type === 'GetURLTitle/Result') {
-          if (response.ok) {
+        if (isGetURLTitleResultMessage(response)) {
+          if (response?.ok) {
             return response.title;
           }
         }
@@ -291,9 +291,9 @@ const toEntityURL = async (
   logger.debug('Request to expand t.co URL', request);
   const { expandedURL, title } = await browser.runtime
     .sendMessage(request)
-    .then((response: ExpandTCoURLResultMessage) => {
+    .then((response: unknown) => {
       logger.debug('Response to request', response);
-      if (response?.type === 'ExpandTCoURL/Result') {
+      if (isExpandTCoURLResultMessage(response)) {
         if (response?.ok) {
           const { expandedURL, title } = response;
           return { expandedURL, title };

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -132,3 +132,44 @@ export async function forwardMessageToOffscreen(
   await offscreen.close();
   return response;
 }
+
+// type guard
+type AnyMessage = {
+  type?: string;
+};
+
+export const isExpandTCoURLRequestMessage = (
+  value: unknown,
+): value is ExpandTCoURLRequestMessage => {
+  return (value as AnyMessage)?.type === 'ExpandTCoURL/Request';
+};
+
+export const isExpandTCoURLResultMessage = (
+  value: unknown,
+): value is ExpandTCoURLResultMessage => {
+  return (value as AnyMessage)?.type === 'ExpandTCoURL/Result';
+};
+
+export const isForwardToOffscreenMessage = <Message extends AnyMessage>(
+  value: unknown,
+): value is ForwardToOffscreenMessage<Message> => {
+  return (value as AnyMessage)?.type === 'Forward/ToOffscreen';
+};
+
+export const isGetURLTitleRequestMessage = (
+  value: unknown,
+): value is GetURLTitleRequestMessage => {
+  return (value as AnyMessage)?.type === 'GetURLTitle/Request';
+};
+
+export const isGetURLTitleResultMessage = (
+  value: unknown,
+): value is GetURLTitleResultMessage => {
+  return (value as AnyMessage)?.type === 'GetURLTitle/Result';
+};
+
+export const isSettingsDownloadStorageMessage = (
+  value: unknown,
+): value is SettingsDownloadStorageMessage => {
+  return (value as AnyMessage)?.type === 'Settings/DownloadStorage';
+};

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -108,19 +108,19 @@ export async function forwardMessageToOffscreen(
   offscreen: Offscreen,
   message: ExpandTCoURLRequestMessage,
   logger: Logger,
-): Promise<ExpandTCoURLResultMessage>;
+): Promise<ExpandTCoURLResultMessage | void>;
 
 export async function forwardMessageToOffscreen(
   offscreen: Offscreen,
   message: GetURLTitleRequestMessage,
   logger: Logger,
-): Promise<GetURLTitleResultMessage>;
+): Promise<GetURLTitleResultMessage | void>;
 
 export async function forwardMessageToOffscreen(
   offscreen: Offscreen,
   message: ExpandTCoURLRequestMessage | GetURLTitleRequestMessage,
   logger: Logger,
-): Promise<ExpandTCoURLResultMessage | GetURLTitleResultMessage> {
+): Promise<ExpandTCoURLResultMessage | GetURLTitleResultMessage | void> {
   await offscreen.open();
   logger.debug('forward to offscreen', message);
   const request = {
@@ -130,7 +130,14 @@ export async function forwardMessageToOffscreen(
   const response = await browser.runtime.sendMessage(request);
   logger.debug('response from offscreen', response);
   await offscreen.close();
-  return response;
+  if (
+    (message.type === 'ExpandTCoURL/Request' &&
+      isExpandTCoURLResultMessage(response)) ||
+    (message.type === 'GetURLTitle/Request' &&
+      isGetURLTitleResultMessage(response))
+  ) {
+    return response;
+  }
 }
 
 // type guard

--- a/src/lib/storage/trashbox.ts
+++ b/src/lib/storage/trashbox.ts
@@ -108,17 +108,11 @@ const loadDeletedTweetIDs = async (): Promise<DeletedTweetID[]> => {
 };
 
 // storage listener
-type UpdatedDeletedTweetID = {
-  id: TweetID;
-  before: DeletedTweetID;
-  after: DeletedTweetID;
-};
-
 export type OnChangedTrashbox = {
   trashbox?: {
     added?: DeletedTweetID[];
     deleted?: DeletedTweetID[];
-    updated?: UpdatedDeletedTweetID[];
+    updated?: DeletedTweetID[];
   };
 };
 
@@ -163,7 +157,7 @@ const parseChanges = (
   // categorize added/deleted/updated
   const added: DeletedTweetID[] = [];
   const deleted: DeletedTweetID[] = [];
-  const updated: UpdatedDeletedTweetID[] = [];
+  const updated: DeletedTweetID[] = [];
   changes.forEach(({ before, after }, id) => {
     if (before === undefined) {
       if (after !== undefined) {
@@ -173,7 +167,7 @@ const parseChanges = (
       if (after === undefined) {
         deleted.push(before);
       } else if (!equal(before, after)) {
-        updated.push({ id, before, after });
+        updated.push(after);
       }
     }
   });

--- a/src/lib/storage/tweet-id-key.ts
+++ b/src/lib/storage/tweet-id-key.ts
@@ -16,10 +16,10 @@ export const toTweetID = (key: TweetIDKey): string => {
 };
 
 export class TweetIDKeyMismatchError extends Error {
-  readonly key: TweetIDKey;
+  readonly key: string;
   readonly value: Tweet;
 
-  constructor(key: TweetIDKey, value: Tweet) {
+  constructor(key: string, value: Tweet) {
     super(
       [
         'Tweet IDs of key and value do not match',

--- a/src/lib/storage/tweet-sort.ts
+++ b/src/lib/storage/tweet-sort.ts
@@ -17,13 +17,7 @@ const keyTweetSort = 'tweetSort' as const;
 export const saveTweetSort = async (value: TweetSort): Promise<void> => {
   logger.debug('save tweet-sort', value);
   // JSONSchema validation
-  if (!validateTweetSort(value)) {
-    throw new JSONSchemaValidationError(
-      tweetSortJSONSchema,
-      value,
-      validateTweetSort.errors ?? [],
-    );
-  }
+  assertIsTweetSort(value);
   // set to storage
   await browser.storage.local.set({ [keyTweetSort]: value });
 };
@@ -38,13 +32,7 @@ export const loadTweetSort = async (): Promise<TweetSort | null> => {
     return null;
   }
   // JSONSchema validation
-  if (!validateTweetSort(value)) {
-    throw new JSONSchemaValidationError(
-      tweetSortJSONSchema,
-      value,
-      validateTweetSort.errors ?? [],
-    );
-  }
+  assertIsTweetSort(value);
   return value;
 };
 
@@ -54,13 +42,7 @@ const keyTrashboxSort = 'trashboxSort' as const;
 export const saveTrashboxSort = async (value: TrashboxSort): Promise<void> => {
   logger.debug('save trashbox-sort', value);
   // JSONSchema validation
-  if (!validateTrashboxSort(value)) {
-    throw new JSONSchemaValidationError(
-      trashboxSortJSONSchema,
-      value,
-      validateTrashboxSort.errors ?? [],
-    );
-  }
+  assertIsTrashboxSort(value);
   // set to storage
   await browser.storage.local.set({ [keyTrashboxSort]: value });
 };
@@ -75,13 +57,7 @@ export const loadTrashboxSort = async (): Promise<TrashboxSort | null> => {
     return null;
   }
   // JSONSchema validation
-  if (!validateTrashboxSort(value)) {
-    throw new JSONSchemaValidationError(
-      trashboxSortJSONSchema,
-      value,
-      validateTrashboxSort.errors ?? [],
-    );
-  }
+  assertIsTrashboxSort(value);
   return value;
 };
 
@@ -101,6 +77,7 @@ export const onChangedTweetSort = (
     tweetSortChange?.newValue !== undefined &&
     !equal(tweetSortChange.oldValue, tweetSortChange.newValue)
   ) {
+    assertIsTweetSort(tweetSortChange.newValue);
     result[keyTweetSort] = tweetSortChange.newValue;
   }
   // trashboxSort
@@ -109,7 +86,29 @@ export const onChangedTweetSort = (
     trashboxSortChange?.newValue !== undefined &&
     !equal(trashboxSortChange.oldValue, trashboxSortChange.newValue)
   ) {
+    assertIsTrashboxSort(trashboxSortChange.newValue);
     result[keyTrashboxSort] = trashboxSortChange.newValue;
   }
   return result;
 };
+
+// type guard
+function assertIsTweetSort(value: unknown): asserts value is TweetSort {
+  if (!validateTweetSort(value)) {
+    throw new JSONSchemaValidationError(
+      tweetSortJSONSchema,
+      value,
+      validateTweetSort.errors ?? [],
+    );
+  }
+}
+
+function assertIsTrashboxSort(value: unknown): asserts value is TrashboxSort {
+  if (!validateTrashboxSort(value)) {
+    throw new JSONSchemaValidationError(
+      trashboxSortJSONSchema,
+      value,
+      validateTrashboxSort.errors ?? [],
+    );
+  }
+}

--- a/src/lib/storage/tweet.ts
+++ b/src/lib/storage/tweet.ts
@@ -16,13 +16,7 @@ import {
 export const saveTweets = async (tweets: Tweet[]): Promise<void> => {
   logger.debug('save tweets', tweets);
   // JSON Schema validation
-  if (!validateTweets(tweets)) {
-    throw new JSONSchemaValidationError(
-      tweetsJSONSchema,
-      tweets,
-      validateTweets.errors ?? [],
-    );
-  }
+  assertIsTweets(tweets);
   // set to storage
   await browser.storage.local.set(
     Object.fromEntries(tweets.map((tweet) => [toTweetIDKey(tweet.id), tweet])),
@@ -32,13 +26,7 @@ export const saveTweets = async (tweets: Tweet[]): Promise<void> => {
 export const saveTweet = async (tweet: Tweet): Promise<void> => {
   logger.debug('save tweet', tweet);
   // JSON Schema validation
-  if (!validateTweet(tweet)) {
-    throw new JSONSchemaValidationError(
-      tweetJSONSchema,
-      tweet,
-      validateTweet.errors ?? [],
-    );
-  }
+  assertIsTweet(tweet);
   // set to storage
   await browser.storage.local.set({ [toTweetIDKey(tweet.id)]: tweet });
 };
@@ -64,10 +52,12 @@ export const loadTweets = async (tweetIDs?: TweetID[]): Promise<Tweet[]> => {
           // validation
           if (isTweetIDKey(key)) {
             try {
-              await validateLoadedTweet(key, value);
+              assertIsTweetRecord(key, value);
               tweets.push(value);
             } catch (error: unknown) {
               logger.debug('validation error', error);
+              // delete from storage
+              await browser.storage.local.remove(key);
             }
           }
           return tweets;
@@ -89,7 +79,7 @@ export const loadTweet = async (tweetID: TweetID): Promise<Tweet | null> => {
     return null;
   }
   // validation
-  await validateLoadedTweet(key, tweet);
+  assertIsTweet(tweet);
   return tweet;
 };
 
@@ -105,26 +95,6 @@ export const deleteTweet = async (tweetID: TweetID): Promise<void> => {
   logger.debug('delete tweet', tweetID);
   // remove from storage
   await browser.storage.local.remove(toTweetIDKey(tweetID));
-};
-
-const validateLoadedTweet = async (
-  key: string,
-  value: Tweet,
-): Promise<void> => {
-  // validation with JSONSchema
-  if (!validateTweet(value)) {
-    await browser.storage.local.remove(key);
-    throw new JSONSchemaValidationError(
-      tweetJSONSchema,
-      value,
-      validateTweet.errors ?? [],
-    );
-  }
-  // tweet ID key
-  if (key !== toTweetIDKey(value.id)) {
-    await browser.storage.local.remove(key);
-    throw new TweetIDKeyMismatchError(key, value);
-  }
 };
 
 // storage listener
@@ -144,15 +114,17 @@ export const onChangedTweet = (
   const updated: Tweet[] = [];
   Object.entries(changes).forEach(([key, { oldValue, newValue }]) => {
     if (isTweetIDKey(key)) {
-      if (newValue !== undefined) {
-        if (oldValue !== undefined) {
-          updated.push(newValue);
+      const newTweet = toTweet(newValue);
+      const oldTweet = toTweet(oldValue);
+      if (newTweet !== undefined) {
+        if (oldTweet !== undefined) {
+          updated.push(newTweet);
         } else {
-          added.push(newValue);
+          added.push(newTweet);
         }
       } else {
-        if (oldValue !== undefined) {
-          deleted.push(oldValue);
+        if (oldTweet !== undefined) {
+          deleted.push(oldTweet);
         }
       }
     }
@@ -165,4 +137,50 @@ export const onChangedTweet = (
   return {
     ...(Object.keys(tweet).length > 0 && { tweet }),
   };
+};
+
+// type guard
+function assertIsTweet(value: unknown): asserts value is Tweet {
+  // JSONSchema validation
+  if (!validateTweet(value)) {
+    throw new JSONSchemaValidationError(
+      tweetJSONSchema,
+      value,
+      validateTweet.errors ?? [],
+    );
+  }
+}
+
+function assertIsTweets(value: unknown): asserts value is Tweet[] {
+  if (!validateTweets(value)) {
+    throw new JSONSchemaValidationError(
+      tweetsJSONSchema,
+      value,
+      validateTweets.errors ?? [],
+    );
+  }
+}
+
+function assertIsTweetRecord(
+  key: string,
+  value: unknown,
+): asserts value is Tweet {
+  // JSONSchema validation
+  assertIsTweet(value);
+  // key check
+  if (key !== toTweetIDKey(value.id)) {
+    throw new TweetIDKeyMismatchError(key, value);
+  }
+}
+
+const toTweet = (value: unknown): Tweet | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    assertIsTweet(value);
+    return value;
+  } catch {
+    return undefined;
+  }
 };

--- a/src/lib/storage/tweet.ts
+++ b/src/lib/storage/tweet.ts
@@ -129,17 +129,11 @@ const validateLoadedTweet = async (
 };
 
 // storage listener
-type UpdatedTweet = {
-  id: TweetID;
-  before: Tweet;
-  after: Tweet;
-};
-
 export type OnChangedTweet = {
   tweet?: {
     added?: Tweet[];
     deleted?: Tweet[];
-    updated?: UpdatedTweet[];
+    updated?: Tweet[];
   };
 };
 
@@ -148,19 +142,19 @@ export const onChangedTweet = (
 ): OnChangedTweet => {
   const added: Tweet[] = [];
   const deleted: Tweet[] = [];
-  const updated: UpdatedTweet[] = [];
+  const updated: Tweet[] = [];
   Object.entries(changes).forEach(([key, { oldValue, newValue }]) => {
     if (isTweetIDKey(key)) {
-      if (oldValue === undefined) {
-        added.push(newValue);
-      } else if (newValue === undefined) {
-        deleted.push(oldValue);
+      if (newValue !== undefined) {
+        if (oldValue !== undefined) {
+          updated.push(newValue);
+        } else {
+          added.push(newValue);
+        }
       } else {
-        updated.push({
-          id: toTweetID(key),
-          before: oldValue,
-          after: newValue,
-        });
+        if (oldValue !== undefined) {
+          deleted.push(oldValue);
+        }
       }
     }
   });

--- a/src/lib/storage/tweet.ts
+++ b/src/lib/storage/tweet.ts
@@ -6,7 +6,6 @@ import validateTweets from '~/validate-json/validate-tweets';
 import type { Tweet, TweetID } from '../tweet/types';
 import { logger } from './logger';
 import {
-  type TweetIDKey,
   TweetIDKeyMismatchError,
   isTweetIDKey,
   toTweetID,
@@ -109,7 +108,7 @@ export const deleteTweet = async (tweetID: TweetID): Promise<void> => {
 };
 
 const validateLoadedTweet = async (
-  key: TweetIDKey,
+  key: string,
   value: Tweet,
 ): Promise<void> => {
   // validation with JSONSchema


### PR DESCRIPTION
# Add Type Guards

Add type guards for `@types/webextension-polifill` version 0.12.1.

In `@types/webextension-polifill` version 0.12.1, `any` is changed to `unknown` in some places, so type guards are required to fix compile errors.