### PR TITLE
Fix Storage Download

### DIFF
--- a/src/app/component/settings.tsx
+++ b/src/app/component/settings.tsx
@@ -20,7 +20,7 @@ import TwitterIcon from '~/icon/twitter.svg';
 import { Collapse } from '~/lib/component/transition';
 import { XIcon } from '~/lib/component/x-icon';
 import { isValidTimezone, toDatetime } from '~/lib/datetime';
-import { SettingsDownloadStorageMessage } from '~/lib/message';
+import type { StorageDownloadMessage } from '~/lib/message';
 import {
   baseURL,
   hostnames,
@@ -545,8 +545,8 @@ const DevTools: React.FC = () => {
 
 const DownloadStorage: React.FC = () => {
   const onClick = async () => {
-    const message: SettingsDownloadStorageMessage = {
-      type: 'Settings/DownloadStorage',
+    const message: StorageDownloadMessage = {
+      type: 'Storage/Download',
     };
     browser.runtime.sendMessage(message);
   };

--- a/src/app/component/settings.tsx
+++ b/src/app/component/settings.tsx
@@ -545,10 +545,20 @@ const DevTools: React.FC = () => {
 
 const DownloadStorage: React.FC = () => {
   const onClick = async () => {
+    // create object URL
+    const data = await browser.storage.local.get();
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    });
+    const objectURL = await URL.createObjectURL(blob);
+    // send message
     const message: StorageDownloadMessage = {
       type: 'Storage/Download',
+      objectURL,
     };
-    browser.runtime.sendMessage(message);
+    await browser.runtime.sendMessage(message);
+    // revoke object URL
+    URL.revokeObjectURL(objectURL);
   };
   return (
     <SettingsItem

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -6,7 +6,7 @@ import {
   forwardMessageToOffscreen,
   isExpandTCoURLRequestMessage,
   isGetURLTitleRequestMessage,
-  isSettingsDownloadStorageMessage,
+  isStorageDownloadMessage,
   respondToExpandTCoURLRequest,
   respondToGetURLTitleRequest,
 } from '~/lib/message';
@@ -41,7 +41,7 @@ const onMessageListener = async (
   if (
     !isExpandTCoURLRequestMessage(message) &&
     !isGetURLTitleRequestMessage(message) &&
-    !isSettingsDownloadStorageMessage(message)
+    !isStorageDownloadMessage(message)
   ) {
     logger.debug('skip message', message);
     return;
@@ -58,7 +58,7 @@ const onMessageListener = async (
       return process.env.TARGET_BROWSER !== 'chrome' ?
           await respondToGetURLTitleRequest(message.url, logger)
         : await forwardMessageToOffscreen(offscreen, message, logger);
-    case 'Settings/DownloadStorage':
+    case 'Storage/Download':
       await downloadStorage();
       break;
     default: {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -59,8 +59,14 @@ const onMessageListener = async (
           await respondToGetURLTitleRequest(message.url, logger)
         : await forwardMessageToOffscreen(offscreen, message, logger);
     case 'Storage/Download':
-      await downloadStorage();
-      break;
+      if (process.env.NODE_ENV === 'development') {
+        await browser.downloads.download({
+          url: message.objectURL,
+          filename: 'scrapbox-copy-tweets.json',
+          saveAs: true,
+        });
+      }
+      return;
     default: {
       const _: never = message;
       return _;
@@ -92,18 +98,3 @@ browser.action.onClicked.addListener(
 
 // offscreen (for chrome)
 const offscreen = setupOffscreen(logger);
-
-// Download storage (in development)
-const downloadStorage = async (): Promise<void> => {
-  if (process.env.NODE_ENV === 'development') {
-    const data = await browser.storage.local.get();
-    const blob = new Blob([JSON.stringify(data, null, 2)], {
-      type: 'application/json',
-    });
-    browser.downloads.download({
-      url: await URL.createObjectURL(blob),
-      filename: 'scrapbox-copy-tweets.json',
-      saveAs: true,
-    });
-  }
-};

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -55,6 +55,7 @@ export type GetURLTitleResultMessage =
 
 export interface StorageDownloadMessage {
   type: 'Storage/Download';
+  objectURL: string;
 }
 
 // Respond to ExpandTCoURL/Request

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -53,8 +53,8 @@ export type GetURLTitleResultMessage =
   | GetURLTitleSuccessMessage
   | GetURLTitleFailureMessage;
 
-export interface SettingsDownloadStorageMessage {
-  type: 'Settings/DownloadStorage';
+export interface StorageDownloadMessage {
+  type: 'Storage/Download';
 }
 
 // Respond to ExpandTCoURL/Request
@@ -175,8 +175,8 @@ export const isGetURLTitleResultMessage = (
   return (value as AnyMessage)?.type === 'GetURLTitle/Result';
 };
 
-export const isSettingsDownloadStorageMessage = (
+export const isStorageDownloadMessage = (
   value: unknown,
-): value is SettingsDownloadStorageMessage => {
-  return (value as AnyMessage)?.type === 'Settings/DownloadStorage';
+): value is StorageDownloadMessage => {
+  return (value as AnyMessage)?.type === 'Storage/Download';
 };


### PR DESCRIPTION
# Fix Storage Download on Chrome

`URL.createObjectURL()` is not available in Service Worker.
Threrefor downloads were failing on Chrome.

To fix it, create object URL outside the background